### PR TITLE
Remove obsolete AppVeyor VersionPrefix from csproj

### DIFF
--- a/src/Autofac.Pooling/Autofac.Pooling.csproj
+++ b/src/Autofac.Pooling/Autofac.Pooling.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <!-- VersionPrefix patched by AppVeyor -->
-    <VersionPrefix>0.0.1</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property and associated AppVeyor comment from the source .csproj
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary
- Eliminates risk of accidentally building with a dummy `0.0.1` version outside the normal pipeline

## Test plan
- [ ] CI build passes (version still correctly set by default.proj)
- [ ] Verify produced package has correct version suffix based on branch