### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,82 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be PascalCase
-dotnet_naming_rule.static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_fields_should_be_pascal_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -110,19 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -148,43 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,53 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="14.0">
-  <!-- https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Use trailing comma in initializers - lots of false positives for enums in StyleCop 1.1.0-beta004 -->
-    <Rule Id="SA1413" Action="None" />
-    <!-- No single-line statements involving braces -->
-    <Rule Id="SA1501" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- File must have header -->
-    <Rule Id="SA1633" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
+    <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+    <Rule Id="CA1031" Action="None" />
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+    <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <Rule Id="CA1812" Action="None" />
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <Rule Id="CA1822" Action="None" />
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <Rule Id="CA2229" Action="None" />
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Prefix local calls with this. -->
+    <Rule Id="SA1101" Action="None" />
+    <!-- Use built-in type alias. -->
+    <Rule Id="SA1121" Action="None" />
+    <!-- Use String.Empty instead of "". -->
+    <Rule Id="SA1122" Action="None" />
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1201" Action="None" />
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1202" Action="None" />
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <Rule Id="SA1204" Action="None" />
+    <!-- Fields can't start with underscore. -->
+    <Rule Id="SA1309" Action="None" />
+    <!-- Elements should be documented. -->
+    <Rule Id="SA1600" Action="None" />
+    <!-- Partial items should be documented. -->
+    <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
+    <Rule Id="SA1602" Action="None" />
+    <!-- Parameter should be documented. -->
+    <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
+    <Rule Id="SA1612" Action="None" />
+    <!-- Return value must be documented. -->
+    <Rule Id="SA1615" Action="None" />
+    <!-- Generic type parameters must be documented. -->
+    <Rule Id="SA1618" Action="None" />
+    <!-- Don't copy/paste documentation. -->
+    <Rule Id="SA1625" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
+    <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
+    <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
+    <Rule Id="IDE0060" Action="None" />
+  </Rules>
+</RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Autofac Project",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} License. See {licenseFile} in the project root for license information.",
+      "variables": {
+        "licenseFile": "LICENSE",
+        "licenseName": "MIT"
+      },
+      "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}

--- a/default.proj
+++ b/default.proj
@@ -57,8 +57,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <MakeDir Directories="$([System.IO.Path]::Combine($(PackageDirectory),%(PublishProject.Filename)))" />
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Pooling/Autofac.Pooling.csproj
+++ b/src/Autofac.Pooling/Autofac.Pooling.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Autofac" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="3.1.5" />
 

--- a/src/Autofac.Pooling/AutofacPooledObjectPolicy.cs
+++ b/src/Autofac.Pooling/AutofacPooledObjectPolicy.cs
@@ -4,52 +4,51 @@
 using Autofac.Core;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Provides the <see cref="IPooledObjectPolicy{TLimit}"/> needed for creating/returning objects in the pool in an Autofac way.
+/// </summary>
+/// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
+internal class AutofacPooledObjectPolicy<TPooledObject> : IPooledObjectPolicy<TPooledObject>
+    where TPooledObject : class
 {
+    private readonly Service _poolInstanceService;
+    private readonly ILifetimeScope _poolOwningScope;
+    private readonly IPooledRegistrationPolicy<TPooledObject> _servicePolicy;
+
     /// <summary>
-    /// Provides the <see cref="IPooledObjectPolicy{TLimit}"/> needed for creating/returning objects in the pool in an Autofac way.
+    /// Initializes a new instance of the <see cref="AutofacPooledObjectPolicy{TLimit}"/> class.
     /// </summary>
-    /// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
-    internal class AutofacPooledObjectPolicy<TPooledObject> : IPooledObjectPolicy<TPooledObject>
-        where TPooledObject : class
+    /// <param name="poolInstanceService">The pooled instance service used to resolve a new instance of the pooled items.</param>
+    /// <param name="poolOwningScope">The owning scope of the pool.</param>
+    /// <param name="registrationPolicy">The registration policy for the pool.</param>
+    public AutofacPooledObjectPolicy(Service poolInstanceService, ILifetimeScope poolOwningScope, IPooledRegistrationPolicy<TPooledObject> registrationPolicy)
     {
-        private readonly Service _poolInstanceService;
-        private readonly ILifetimeScope _poolOwningScope;
-        private readonly IPooledRegistrationPolicy<TPooledObject> _servicePolicy;
+        _poolInstanceService = poolInstanceService;
+        _poolOwningScope = poolOwningScope;
+        _servicePolicy = registrationPolicy;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AutofacPooledObjectPolicy{TLimit}"/> class.
-        /// </summary>
-        /// <param name="poolInstanceService">The pooled instance service used to resolve a new instance of the pooled items.</param>
-        /// <param name="poolOwningScope">The owning scope of the pool.</param>
-        /// <param name="registrationPolicy">The registration policy for the pool.</param>
-        public AutofacPooledObjectPolicy(Service poolInstanceService, ILifetimeScope poolOwningScope, IPooledRegistrationPolicy<TPooledObject> registrationPolicy)
+    /// <inheritdoc/>
+    public TPooledObject Create()
+    {
+        return (TPooledObject)_poolOwningScope.ResolveService(_poolInstanceService);
+    }
+
+    /// <inheritdoc/>
+    public bool Return(TPooledObject obj)
+    {
+        if (obj is IPooledComponent poolAwareComponent)
         {
-            _poolInstanceService = poolInstanceService;
-            _poolOwningScope = poolOwningScope;
-            _servicePolicy = registrationPolicy;
+            poolAwareComponent.OnReturnToPool();
         }
 
-        /// <inheritdoc/>
-        public TPooledObject Create()
+        if (_servicePolicy.Return(obj))
         {
-            return (TPooledObject)_poolOwningScope.ResolveService(_poolInstanceService);
+            return true;
         }
 
-        /// <inheritdoc/>
-        public bool Return(TPooledObject obj)
-        {
-            if (obj is IPooledComponent poolAwareComponent)
-            {
-                poolAwareComponent.OnReturnToPool();
-            }
-
-            if (_servicePolicy.Return(obj))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        return false;
     }
 }

--- a/src/Autofac.Pooling/DefaultPooledRegistrationPolicy.cs
+++ b/src/Autofac.Pooling/DefaultPooledRegistrationPolicy.cs
@@ -5,56 +5,58 @@ using System;
 using System.Collections.Generic;
 using Autofac.Core;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Provides the default <see cref="IPooledRegistrationPolicy{TPooledObject}"/>.
+/// </summary>
+/// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
+public class DefaultPooledRegistrationPolicy<TPooledObject> : IPooledRegistrationPolicy<TPooledObject>
+    where TPooledObject : class
 {
     /// <summary>
-    /// Provides the default <see cref="IPooledRegistrationPolicy{TPooledObject}"/>.
+    /// Initializes a new instance of the <see cref="DefaultPooledRegistrationPolicy{TLimit}"/> class.
     /// </summary>
-    /// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
-    public class DefaultPooledRegistrationPolicy<TPooledObject> : IPooledRegistrationPolicy<TPooledObject>
-        where TPooledObject : class
+    public DefaultPooledRegistrationPolicy()
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultPooledRegistrationPolicy{TLimit}"/> class.
-        /// </summary>
-        public DefaultPooledRegistrationPolicy()
+        // Based on the default ObjectPool size in the .NET Runtime.
+        MaximumRetained = Environment.ProcessorCount * 2;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultPooledRegistrationPolicy{TLimit}"/> class.
+    /// </summary>
+    /// <param name="maximumRetained">The maximum number of instances that should be retained in the pool.</param>
+    public DefaultPooledRegistrationPolicy(int maximumRetained)
+    {
+        if (maximumRetained < 0)
         {
-            // Based on the default ObjectPool size in the .NET Runtime.
-            MaximumRetained = Environment.ProcessorCount * 2;
+            throw new ArgumentOutOfRangeException(nameof(maximumRetained));
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultPooledRegistrationPolicy{TLimit}"/> class.
-        /// </summary>
-        /// <param name="maximumRetained">The maximum number of instances that should be retained in the pool.</param>
-        public DefaultPooledRegistrationPolicy(int maximumRetained)
-        {
-            if (maximumRetained < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maximumRetained));
-            }
+        MaximumRetained = maximumRetained;
+    }
 
-            MaximumRetained = maximumRetained;
+    /// <inheritdoc/>
+    public int MaximumRetained
+    {
+        get;
+    }
+
+    /// <inheritdoc/>
+    public virtual TPooledObject Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TPooledObject> getFromPool)
+    {
+        if (getFromPool is null)
+        {
+            throw new ArgumentNullException(nameof(getFromPool));
         }
 
-        /// <inheritdoc/>
-        public int MaximumRetained { get; }
+        return getFromPool();
+    }
 
-        /// <inheritdoc/>
-        public virtual TPooledObject Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TPooledObject> getFromPool)
-        {
-            if (getFromPool is null)
-            {
-                throw new ArgumentNullException(nameof(getFromPool));
-            }
-
-            return getFromPool();
-        }
-
-        /// <inheritdoc/>
-        public virtual bool Return(TPooledObject pooledObject)
-        {
-            return true;
-        }
+    /// <inheritdoc/>
+    public virtual bool Return(TPooledObject pooledObject)
+    {
+        return true;
     }
 }

--- a/src/Autofac.Pooling/IPooledComponent.cs
+++ b/src/Autofac.Pooling/IPooledComponent.cs
@@ -5,34 +5,33 @@ using System;
 using System.Collections.Generic;
 using Autofac.Core;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Components implementing this interface are aware that they are pooled, so will be notified when they are retrieved from the pool,
+/// and when they are returned to the pool.
+/// </summary>
+public interface IPooledComponent
 {
     /// <summary>
-    /// Components implementing this interface are aware that they are pooled, so will be notified when they are retrieved from the pool,
-    /// and when they are returned to the pool.
+    /// Invoked when this instance is retrieved from the pool. Any dependencies retrieved using the provided <see cref="IComponentContext"/>
+    /// MUST be discarded in <see cref="OnReturnToPool"/>, otherwise memory leaks may occur.
     /// </summary>
-    public interface IPooledComponent
-    {
-        /// <summary>
-        /// Invoked when this instance is retrieved from the pool. Any dependencies retrieved using the provided <see cref="IComponentContext"/>
-        /// MUST be discarded in <see cref="OnReturnToPool"/>, otherwise memory leaks may occur.
-        /// </summary>
-        /// <param name="context">The component context for the current resolve request.</param>
-        /// <param name="parameters">The parameters to the resolve request.</param>
-        void OnGetFromPool(IComponentContext context, IEnumerable<Parameter> parameters);
+    /// <param name="context">The component context for the current resolve request.</param>
+    /// <param name="parameters">The parameters to the resolve request.</param>
+    void OnGetFromPool(IComponentContext context, IEnumerable<Parameter> parameters);
 
-        /// <summary>
-        /// <para>
-        /// Invoked when this instance is being returned to the pool. Any dependencies retrieved in <see cref="OnGetFromPool"/> should
-        /// be discarded in this method.
-        /// </para>
-        ///
-        /// <para>
-        /// If the maximum pool capacity has been reached (or a custom <see cref="IPooledRegistrationPolicy{T}"/> decides not to return the instance to the pool),
-        /// this method will be invoked, but then the object will not be put back in
-        /// the pool (and may be disposed if the component implements <see cref="IDisposable"/>).
-        /// </para>
-        /// </summary>
-        void OnReturnToPool();
-    }
+    /// <summary>
+    /// <para>
+    /// Invoked when this instance is being returned to the pool. Any dependencies retrieved in <see cref="OnGetFromPool"/> should
+    /// be discarded in this method.
+    /// </para>
+    ///
+    /// <para>
+    /// If the maximum pool capacity has been reached (or a custom <see cref="IPooledRegistrationPolicy{T}"/> decides not to return the instance to the pool),
+    /// this method will be invoked, but then the object will not be put back in
+    /// the pool (and may be disposed if the component implements <see cref="IDisposable"/>).
+    /// </para>
+    /// </summary>
+    void OnReturnToPool();
 }

--- a/src/Autofac.Pooling/IPooledRegistrationPolicy.cs
+++ b/src/Autofac.Pooling/IPooledRegistrationPolicy.cs
@@ -5,40 +5,43 @@ using System;
 using System.Collections.Generic;
 using Autofac.Core;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Defines the interface for a custom pooled registration policy, that defines what happens when an instance is retrieved from the pool, and
+/// what happens when the instance is returned to the pool.
+/// </summary>
+/// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
+public interface IPooledRegistrationPolicy<TPooledObject>
+    where TPooledObject : class
 {
     /// <summary>
-    /// Defines the interface for a custom pooled registration policy, that defines what happens when an instance is retrieved from the pool, and
-    /// what happens when the instance is returned to the pool.
+    /// Gets a value indicating the maximum number of items that will be retained in the pool. This is not a limit on the number of
+    /// objects that can be created, it's the threshold past which any objects returned to the pool will be discarded.
     /// </summary>
-    /// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
-    public interface IPooledRegistrationPolicy<TPooledObject>
-        where TPooledObject : class
+    int MaximumRetained
     {
-        /// <summary>
-        /// Gets a value indicating the maximum number of items that will be retained in the pool. This is not a limit on the number of
-        /// objects that can be created, it's the threshold past which any objects returned to the pool will be discarded.
-        /// </summary>
-        int MaximumRetained { get; }
-
-        /// <summary>
-        /// Invoked when an instance of <typeparamref name="TPooledObject"/> is requested. The policy can invoke <paramref name="getFromPool"/> to
-        /// retrieve an instance from the pool. Equally, it could decide to ignore the pool, and just return a custom instance.
-        /// </summary>
-        /// <param name="context">The current component context.</param>
-        /// <param name="parameters">The set of parameters for the resolve request accessing the pool.</param>
-        /// <param name="getFromPool">A callback that will retrieve an item from the underlying pool of objects.</param>
-        TPooledObject Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TPooledObject> getFromPool);
-
-        /// <summary>
-        /// Invoked when an object is about to be returned into the pool. This method should be used to clean up the state of the object
-        /// after being used (resetting connections, releasing temporary resources, etc).
-        /// </summary>
-        /// <param name="pooledObject">The pooled object.</param>
-        /// <returns>
-        /// True if the object should be returned to the pool.
-        /// False if it should not be placed back in the pool (and will be disposed immediately if it implements <see cref="IDisposable"/>).
-        /// </returns>
-        bool Return(TPooledObject pooledObject);
+        get;
     }
+
+    /// <summary>
+    /// Invoked when an instance of <typeparamref name="TPooledObject"/> is requested. The policy can invoke <paramref name="getFromPool"/> to
+    /// retrieve an instance from the pool. Equally, it could decide to ignore the pool, and just return a custom instance.
+    /// </summary>
+    /// <param name="context">The current component context.</param>
+    /// <param name="parameters">The set of parameters for the resolve request accessing the pool.</param>
+    /// <param name="getFromPool">A callback that will retrieve an item from the underlying pool of objects.</param>
+    /// <returns>An instance of <typeparamref name="TPooledObject"/> from the pool or a custom instance.</returns>
+    TPooledObject Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TPooledObject> getFromPool);
+
+    /// <summary>
+    /// Invoked when an object is about to be returned into the pool. This method should be used to clean up the state of the object
+    /// after being used (resetting connections, releasing temporary resources, etc).
+    /// </summary>
+    /// <param name="pooledObject">The pooled object.</param>
+    /// <returns>
+    /// True if the object should be returned to the pool.
+    /// False if it should not be placed back in the pool (and will be disposed immediately if it implements <see cref="IDisposable"/>).
+    /// </returns>
+    bool Return(TPooledObject pooledObject);
 }

--- a/src/Autofac.Pooling/PoolActivator.cs
+++ b/src/Autofac.Pooling/PoolActivator.cs
@@ -6,57 +6,56 @@ using Autofac.Core;
 using Autofac.Core.Resolving.Pipeline;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// An activator for creating new <see cref="ObjectPool{TLimit}"/> instances.
+/// </summary>
+/// <typeparam name="TLimit">The limit type of the objects in the pool.</typeparam>
+internal sealed class PoolActivator<TLimit> : IInstanceActivator
+    where TLimit : class
 {
+    private readonly Service _pooledInstanceService;
+    private readonly IPooledRegistrationPolicy<TLimit> _policy;
+    private readonly DefaultObjectPoolProvider _poolProvider;
+
     /// <summary>
-    /// An activator for creating new <see cref="ObjectPool{TLimit}"/> instances.
+    /// Initializes a new instance of the <see cref="PoolActivator{TLimit}"/> class.
     /// </summary>
-    /// <typeparam name="TLimit">The limit type of the objects in the pool.</typeparam>
-    internal sealed class PoolActivator<TLimit> : IInstanceActivator
-        where TLimit : class
+    /// <param name="pooledInstanceService">The service used to resolve new instances of the pooled registration.</param>
+    /// <param name="policy">The pool policy.</param>
+    public PoolActivator(Service pooledInstanceService, IPooledRegistrationPolicy<TLimit> policy)
     {
-        private readonly Service _pooledInstanceService;
-        private readonly IPooledRegistrationPolicy<TLimit> _policy;
-        private readonly DefaultObjectPoolProvider _poolProvider;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PoolActivator{TLimit}"/> class.
-        /// </summary>
-        /// <param name="pooledInstanceService">The service used to resolve new instances of the pooled registration.</param>
-        /// <param name="policy">The pool policy.</param>
-        public PoolActivator(Service pooledInstanceService, IPooledRegistrationPolicy<TLimit> policy)
+        _pooledInstanceService = pooledInstanceService;
+        _policy = policy;
+        _poolProvider = new DefaultObjectPoolProvider
         {
-            _pooledInstanceService = pooledInstanceService;
-            _policy = policy;
-            _poolProvider = new DefaultObjectPoolProvider
-            {
-                MaximumRetained = policy.MaximumRetained
-            };
-        }
+            MaximumRetained = policy.MaximumRetained,
+        };
+    }
 
-        /// <inheritdoc/>
-        public Type LimitType { get; } = typeof(TLimit);
+    /// <inheritdoc/>
+    public Type LimitType { get; } = typeof(TLimit);
 
-        /// <inheritdoc/>
-        public void ConfigurePipeline(IComponentRegistryServices componentRegistryServices, IResolvePipelineBuilder pipelineBuilder)
+    /// <inheritdoc/>
+    public void ConfigurePipeline(IComponentRegistryServices componentRegistryServices, IResolvePipelineBuilder pipelineBuilder)
+    {
+        pipelineBuilder.Use(PipelinePhase.Activation, (context, next) =>
         {
-            pipelineBuilder.Use(PipelinePhase.Activation, (context, next) =>
-            {
-                // Get a reference to the actual lifetime scope.
-                var scope = context.Resolve<ILifetimeScope>();
+            // Get a reference to the actual lifetime scope.
+            var scope = context.Resolve<ILifetimeScope>();
 
-                var poolPolicy = new AutofacPooledObjectPolicy<TLimit>(_pooledInstanceService, scope, _policy);
+            var poolPolicy = new AutofacPooledObjectPolicy<TLimit>(_pooledInstanceService, scope, _policy);
 
-                // The pool provider will create a disposable pool if the TLimit implements IDisposable.
-                var pool = _poolProvider.Create(poolPolicy);
+            // The pool provider will create a disposable pool if the TLimit implements IDisposable.
+            var pool = _poolProvider.Create(poolPolicy);
 
-                context.Instance = pool;
-            });
-        }
+            context.Instance = pool;
+        });
+    }
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-        }
+    /// <inheritdoc/>
+    public void Dispose()
+    {
     }
 }

--- a/src/Autofac.Pooling/PoolGetActivator.cs
+++ b/src/Autofac.Pooling/PoolGetActivator.cs
@@ -7,81 +7,75 @@ using Autofac.Core;
 using Autofac.Core.Resolving.Pipeline;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Activator that resolves the object pool and retrieves from that rather than creating a new instance.
+/// </summary>
+/// <typeparam name="TLimit">The limit type of the objects in the pool.</typeparam>
+internal sealed class PoolGetActivator<TLimit> : IInstanceActivator
+    where TLimit : class
 {
+    private readonly PoolService _poolService;
+    private readonly IPooledRegistrationPolicy<TLimit> _registrationPolicy;
+
     /// <summary>
-    /// Activator that resolves the object pool and retrieves from that rather than creating a new instance.
+    /// Initializes a new instance of the <see cref="PoolGetActivator{TLimit}"/> class.
     /// </summary>
-    /// <typeparam name="TLimit">The limit type of the objects in the pool.</typeparam>
-    internal sealed class PoolGetActivator<TLimit> : IInstanceActivator
-        where TLimit : class
+    /// <param name="poolService">The service used to access the pool.</param>
+    /// <param name="registrationPolicy">The registration policy for the pool.</param>
+    public PoolGetActivator(PoolService poolService, IPooledRegistrationPolicy<TLimit> registrationPolicy)
     {
-        private readonly PoolService _poolService;
-        private readonly IPooledRegistrationPolicy<TLimit> _registrationPolicy;
+        _poolService = poolService;
+        _registrationPolicy = registrationPolicy;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PoolGetActivator{TLimit}"/> class.
-        /// </summary>
-        /// <param name="poolService">The service used to access the pool.</param>
-        /// <param name="registrationPolicy">The registration policy for the pool.</param>
-        public PoolGetActivator(PoolService poolService, IPooledRegistrationPolicy<TLimit> registrationPolicy)
+    /// <inheritdoc/>
+    public Type LimitType { get; } = typeof(TLimit);
+
+    /// <inheritdoc/>
+    public void ConfigurePipeline(IComponentRegistryServices componentRegistryServices, IResolvePipelineBuilder pipelineBuilder)
+    {
+        pipelineBuilder.Use(PipelinePhase.Activation, (ctxt, next) =>
         {
-            _poolService = poolService;
-            _registrationPolicy = registrationPolicy;
-        }
+            var pool = (ObjectPool<TLimit>)ctxt.ResolveService(_poolService);
+            var didGetFromPool = false;
 
-        /// <inheritdoc/>
-        public Type LimitType { get; } = typeof(TLimit);
-
-        /// <inheritdoc/>
-        public void ConfigurePipeline(IComponentRegistryServices componentRegistryServices, IResolvePipelineBuilder pipelineBuilder)
-        {
-            pipelineBuilder.Use(PipelinePhase.Activation, (ctxt, next) =>
+            TLimit PoolGet()
             {
-                var pool = (ObjectPool<TLimit>)ctxt.ResolveService(_poolService);
-                var didGetFromPool = false;
+                didGetFromPool = true;
+                return pool.Get();
+            }
 
-                TLimit PoolGet()
+            var poolItem = _registrationPolicy.Get(ctxt, ctxt.Parameters, PoolGet) ?? throw new InvalidOperationException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        PoolGetActivatorResources.PolicyMustReturnInstance,
+                        _registrationPolicy.GetType().FullName,
+                        typeof(TLimit).FullName));
+
+            if (didGetFromPool)
+            {
+                if (poolItem is IPooledComponent poolAwareComponent)
                 {
-                    didGetFromPool = true;
-                    return pool.Get();
+                    poolAwareComponent.OnGetFromPool(ctxt, ctxt.Parameters);
                 }
 
-                var poolItem = _registrationPolicy.Get(ctxt, ctxt.Parameters, PoolGet);
+                // Need to return a 'container' that
+                // gets unpacked just after we're done sharing.
+                // That way disposal of the scope will return to the pool.
+                ctxt.Instance = new PooledInstanceTracker<TLimit>(pool, poolItem);
+            }
+            else
+            {
+                // Instance did not come from the pool, so just use it directly.
+                ctxt.Instance = poolItem;
+            }
+        });
+    }
 
-                if (poolItem is null)
-                {
-                    throw new InvalidOperationException(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            PoolGetActivatorResources.PolicyMustReturnInstance,
-                            _registrationPolicy.GetType().FullName,
-                            typeof(TLimit).FullName));
-                }
-
-                if (didGetFromPool)
-                {
-                    if (poolItem is IPooledComponent poolAwareComponent)
-                    {
-                        poolAwareComponent.OnGetFromPool(ctxt, ctxt.Parameters);
-                    }
-
-                    // Need to return a 'container' that
-                    // gets unpacked just after we're done sharing.
-                    // That way disposal of the scope will return to the pool.
-                    ctxt.Instance = new PooledInstanceTracker<TLimit>(pool, poolItem);
-                }
-                else
-                {
-                    // Instance did not come from the pool, so just use it directly.
-                    ctxt.Instance = poolItem;
-                }
-            });
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-        }
+    /// <inheritdoc/>
+    public void Dispose()
+    {
     }
 }

--- a/src/Autofac.Pooling/PoolService.cs
+++ b/src/Autofac.Pooling/PoolService.cs
@@ -6,46 +6,45 @@ using System.Globalization;
 using Autofac.Core;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Defines a service used to access an <see cref="ObjectPool{T}"/>, ensuring that each pooled item registration gets a different pool.
+/// </summary>
+internal class PoolService : Service, IEquatable<PoolService>
 {
+    private readonly IComponentRegistration _pooledItemRegistration;
+
     /// <summary>
-    /// Defines a service used to access an <see cref="ObjectPool{T}"/>, ensuring that each pooled item registration gets a different pool.
+    /// Initializes a new instance of the <see cref="PoolService"/> class.
     /// </summary>
-    internal class PoolService : Service, IEquatable<PoolService>
+    /// <param name="pooledItemRegistration">The registration for the pooled item.</param>
+    public PoolService(IComponentRegistration pooledItemRegistration)
     {
-        private readonly IComponentRegistration _pooledItemRegistration;
+        _pooledItemRegistration = pooledItemRegistration;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PoolService"/> class.
-        /// </summary>
-        /// <param name="pooledItemRegistration">The registration for the pooled item.</param>
-        public PoolService(IComponentRegistration pooledItemRegistration)
-        {
-            _pooledItemRegistration = pooledItemRegistration;
-        }
+    /// <inheritdoc/>
+    public override string Description => string.Format(
+        CultureInfo.CurrentCulture,
+        PoolServiceResources.Description,
+        _pooledItemRegistration.Activator.LimitType.FullName);
 
-        /// <inheritdoc/>
-        public override string Description => string.Format(
-            CultureInfo.CurrentCulture,
-            PoolServiceResources.Description,
-            _pooledItemRegistration.Activator.LimitType.FullName);
+    /// <inheritdoc/>
+    public bool Equals(PoolService? other)
+    {
+        return other is object && _pooledItemRegistration.Id == other._pooledItemRegistration.Id;
+    }
 
-        /// <inheritdoc/>
-        public bool Equals(PoolService? other)
-        {
-            return other is object && _pooledItemRegistration.Id == other._pooledItemRegistration.Id;
-        }
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as PoolService);
+    }
 
-        /// <inheritdoc/>
-        public override bool Equals(object? obj)
-        {
-            return Equals(obj as PoolService);
-        }
-
-        /// <inheritdoc/>
-        public override int GetHashCode()
-        {
-            return _pooledItemRegistration.Id.GetHashCode();
-        }
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return _pooledItemRegistration.Id.GetHashCode();
     }
 }

--- a/src/Autofac.Pooling/PooledInstanceTracker.cs
+++ b/src/Autofac.Pooling/PooledInstanceTracker.cs
@@ -4,40 +4,42 @@
 using System;
 using Microsoft.Extensions.ObjectPool;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Tracking class that that will return the wrapped instance to the provided pool when it is disposed.
+/// </summary>
+/// <typeparam name="TPooledObject">The type of the object being pooled.</typeparam>
+internal sealed class PooledInstanceTracker<TPooledObject> : IDisposable
+    where TPooledObject : class
 {
+    private readonly ObjectPool<TPooledObject> _pool;
+
     /// <summary>
-    /// Tracking class that that will return the wrapped instance to the provided pool when it is disposed.
+    /// Initializes a new instance of the <see cref="PooledInstanceTracker{TLimit}"/> class.
     /// </summary>
-    /// <typeparam name="TPooledObject">The type of the object being pooled.</typeparam>
-    internal sealed class PooledInstanceTracker<TPooledObject> : IDisposable
-        where TPooledObject : class
+    /// <param name="pool">The pool.</param>
+    /// <param name="instance">The instance to wrap.</param>
+    public PooledInstanceTracker(ObjectPool<TPooledObject> pool, TPooledObject instance)
     {
-        private readonly ObjectPool<TPooledObject> _pool;
+        _pool = pool;
+        Instance = instance;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PooledInstanceTracker{TLimit}"/> class.
-        /// </summary>
-        /// <param name="pool">The pool.</param>
-        /// <param name="instance">The instance to wrap.</param>
-        public PooledInstanceTracker(ObjectPool<TPooledObject> pool, TPooledObject instance)
-        {
-            _pool = pool;
-            Instance = instance;
-        }
+    /// <summary>
+    /// Gets the wrapped instance.
+    /// </summary>
+    public TPooledObject Instance
+    {
+        get;
+    }
 
-        /// <summary>
-        /// Gets the wrapped instance.
-        /// </summary>
-        public TPooledObject Instance { get; }
-
-        /// <summary>
-        /// Disposes the container, returning the instance to the pool.
-        /// </summary>
-        public void Dispose()
-        {
-            // Put the instance back in the pool.
-            _pool.Return(Instance);
-        }
+    /// <summary>
+    /// Disposes the container, returning the instance to the pool.
+    /// </summary>
+    public void Dispose()
+    {
+        // Put the instance back in the pool.
+        _pool.Return(Instance);
     }
 }

--- a/src/Autofac.Pooling/PooledInstanceUnpackMiddleware.cs
+++ b/src/Autofac.Pooling/PooledInstanceUnpackMiddleware.cs
@@ -4,28 +4,27 @@
 using System;
 using Autofac.Core.Resolving.Pipeline;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Middleware for extracting the requested instance from the pool instance container.
+/// </summary>
+/// <typeparam name="TLimit">The limit type of the registration that has been pooled.</typeparam>
+internal sealed class PooledInstanceUnpackMiddleware<TLimit> : IResolveMiddleware
+    where TLimit : class
 {
-    /// <summary>
-    /// Middleware for extracting the requested instance from the pool instance container.
-    /// </summary>
-    /// <typeparam name="TLimit">The limit type of the registration that has been pooled.</typeparam>
-    internal sealed class PooledInstanceUnpackMiddleware<TLimit> : IResolveMiddleware
-        where TLimit : class
+    /// <inheritdoc/>
+    public PipelinePhase Phase => PipelinePhase.Sharing;
+
+    /// <inheritdoc/>
+    public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        /// <inheritdoc/>
-        public PipelinePhase Phase => PipelinePhase.Sharing;
+        next(context);
 
-        /// <inheritdoc/>
-        public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
+        // 'Unpack' the pool instance so what the consumer sees is just the implementation.
+        if (context.Instance is PooledInstanceTracker<TLimit> poolInstanceContainer)
         {
-            next(context);
-
-            // 'Unpack' the pool instance so what the consumer sees is just the implementation.
-            if (context.Instance is PooledInstanceTracker<TLimit> poolInstanceContainer)
-            {
-                context.Instance = poolInstanceContainer.Instance;
-            }
+            context.Instance = poolInstanceContainer.Instance;
         }
     }
 }

--- a/src/Autofac.Pooling/PooledLifetime.cs
+++ b/src/Autofac.Pooling/PooledLifetime.cs
@@ -3,12 +3,11 @@
 
 using Autofac.Core.Lifetime;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Lifetime wrapper to help us detect if we finished registering in a pooled configuration.
+/// </summary>
+public class PooledLifetime : CurrentScopeLifetime
 {
-    /// <summary>
-    /// Lifetime wrapper to help us detect if we finished registering in a pooled configuration.
-    /// </summary>
-    public class PooledLifetime : CurrentScopeLifetime
-    {
-    }
 }

--- a/src/Autofac.Pooling/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Pooling/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;

--- a/src/Autofac.Pooling/RegistrationExtensions.cs
+++ b/src/Autofac.Pooling/RegistrationExtensions.cs
@@ -12,376 +12,370 @@ using Autofac.Core.Registration;
 using Autofac.Core.Resolving.Middleware;
 using Autofac.Core.Resolving.Pipeline;
 
-namespace Autofac.Pooling
+namespace Autofac.Pooling;
+
+/// <summary>
+/// Provides registration methods for setting up pooled instances.
+/// </summary>
+public static class RegistrationExtensions
 {
     /// <summary>
-    /// Provides registration methods for setting up pooled instances.
+    /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
+    /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
     /// </summary>
-    public static class RegistrationExtensions
+    /// <remarks>
+    /// <para>
+    /// The size of the pool created with this method defaults to twice the number of processors (<see cref="Environment.ProcessorCount"/> x 2).
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    ///
+    /// <para>
+    /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
+    /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
     {
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
-        /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The size of the pool created with this method defaults to twice the number of processors (<see cref="Environment.ProcessorCount"/> x 2).
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        ///
-        /// <para>
-        /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
-        /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(), null);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
-        /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The size of the pool created with this method is equal to <paramref name="maximumRetainedInstances"/>.
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        ///
-        /// <para>
-        /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
-        /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <param name="maximumRetainedInstances">The maximum number of instances to retain in the pool.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-                   int maximumRetainedInstances)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(), null);
+
+        return registration;
+    }
+
+    /// <summary>
+    /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
+    /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The size of the pool created with this method is equal to <paramref name="maximumRetainedInstances"/>.
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    ///
+    /// <para>
+    /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
+    /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <param name="maximumRetainedInstances">The maximum number of instances to retain in the pool.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+               int maximumRetainedInstances)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(maximumRetainedInstances), null);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
-        /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This method accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/> that provides fine-grained control of the retrieval
-        /// of instances from the pool, and allows the implementer to choose whether or not the instance should even be returned to the pool.
-        /// </para>
-        ///
-        /// <para>
-        /// The size of the pool created with this method is equal to the <see cref="IPooledRegistrationPolicy{TLimit}.MaximumRetained"/> value on the
-        /// <paramref name="poolPolicy"/>.
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <param name="poolPolicy">A custom policy for controlling pool behaviour.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-                   IPooledRegistrationPolicy<TLimit> poolPolicy)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(maximumRetainedInstances), null);
+
+        return registration;
+    }
+
+    /// <summary>
+    /// Configure the component so that every dependent component or manual resolve within a single <see cref="ILifetimeScope"/>
+    /// will return the same, shared instance, retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/> that provides fine-grained control of the retrieval
+    /// of instances from the pool, and allows the implementer to choose whether or not the instance should even be returned to the pool.
+    /// </para>
+    ///
+    /// <para>
+    /// The size of the pool created with this method is equal to the <see cref="IPooledRegistrationPolicy{TLimit}.MaximumRetained"/> value on the
+    /// <paramref name="poolPolicy"/>.
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <param name="poolPolicy">A custom policy for controlling pool behaviour.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+               IPooledRegistrationPolicy<TLimit> poolPolicy)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, poolPolicy, null);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within
-        /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
-        /// retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// Dependent components in lifetime scopes that are children of the tagged scope will
-        /// share the parent's instance. If no appropriately tagged scope can be found in the
-        /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The size of the pool created with this method defaults to twice the number of processors (<see cref="Environment.ProcessorCount"/> x 2).
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        ///
-        /// <para>
-        /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
-        /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-                   params object[] lifetimeScopeTags)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        RegisterPooled(registration, poolPolicy, null);
+
+        return registration;
+    }
+
+    /// <summary>
+    /// Configure the component so that every dependent component or manual resolve within
+    /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
+    /// retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
+    /// Dependent components in lifetime scopes that are children of the tagged scope will
+    /// share the parent's instance. If no appropriately tagged scope can be found in the
+    /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The size of the pool created with this method defaults to twice the number of processors (<see cref="Environment.ProcessorCount"/> x 2).
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    ///
+    /// <para>
+    /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
+    /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+               params object[] lifetimeScopeTags)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(), lifetimeScopeTags);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within
-        /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
-        /// retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// Dependent components in lifetime scopes that are children of the tagged scope will
-        /// share the parent's instance. If no appropriately tagged scope can be found in the
-        /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The size of the pool created with this method is equal to <paramref name="maximumRetainedInstances"/>.
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        ///
-        /// <para>
-        /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
-        /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <param name="maximumRetainedInstances">The maximum number of instances to retain in the pool.</param>
-        /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-                   int maximumRetainedInstances,
-                   params object[] lifetimeScopeTags)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(), lifetimeScopeTags);
+
+        return registration;
+    }
+
+    /// <summary>
+    /// Configure the component so that every dependent component or manual resolve within
+    /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
+    /// retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
+    /// Dependent components in lifetime scopes that are children of the tagged scope will
+    /// share the parent's instance. If no appropriately tagged scope can be found in the
+    /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The size of the pool created with this method is equal to <paramref name="maximumRetainedInstances"/>.
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    ///
+    /// <para>
+    /// If a component needs to perform behaviour when it is retrieved from or returned to the pool, it can implement <see cref="IPooledComponent"/>,
+    /// or use the overload of this method that accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/>.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <param name="maximumRetainedInstances">The maximum number of instances to retain in the pool.</param>
+    /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+               int maximumRetainedInstances,
+               params object[] lifetimeScopeTags)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(maximumRetainedInstances), lifetimeScopeTags);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        /// <summary>
-        /// Configure the component so that every dependent component or manual resolve within
-        /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
-        /// retrieved from a single pool of instances shared by all lifetime scopes.
-        /// When the scope ends, the instance will be returned to the pool.
-        /// Dependent components in lifetime scopes that are children of the tagged scope will
-        /// share the parent's instance. If no appropriately tagged scope can be found in the
-        /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This method accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/> that provides fine-grained control of the retrieval
-        /// of instances from the pool, and allows the implementer to choose whether or not the instance should even be returned to the pool.
-        /// </para>
-        ///
-        /// <para>
-        /// The size of the pool created with this method is equal to the <see cref="IPooledRegistrationPolicy{TLimit}.MaximumRetained"/> value on the
-        /// <paramref name="poolPolicy"/>.
-        /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
-        /// </para>
-        /// </remarks>
-        /// <typeparam name="TLimit">Registration limit type.</typeparam>
-        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="registration">The registration.</param>
-        /// <param name="poolPolicy">A custom policy for controlling pool behaviour.</param>
-        /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
-        /// <returns>The registration builder.</returns>
-        public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
-               PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
-                   this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-                   IPooledRegistrationPolicy<TLimit> poolPolicy,
-                   params object[] lifetimeScopeTags)
-               where TSingleRegistrationStyle : SingleRegistrationStyle
-               where TActivatorData : IConcreteActivatorData
-               where TLimit : class
+        RegisterPooled(registration, new DefaultPooledRegistrationPolicy<TLimit>(maximumRetainedInstances), lifetimeScopeTags);
+
+        return registration;
+    }
+
+    /// <summary>
+    /// Configure the component so that every dependent component or manual resolve within
+    /// a <see cref="ILifetimeScope"/> tagged with any of the provided tags value gets the same, shared instance,
+    /// retrieved from a single pool of instances shared by all lifetime scopes.
+    /// When the scope ends, the instance will be returned to the pool.
+    /// Dependent components in lifetime scopes that are children of the tagged scope will
+    /// share the parent's instance. If no appropriately tagged scope can be found in the
+    /// hierarchy an <see cref="DependencyResolutionException"/> is thrown.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method accepts a custom <see cref="IPooledRegistrationPolicy{TLimit}"/> that provides fine-grained control of the retrieval
+    /// of instances from the pool, and allows the implementer to choose whether or not the instance should even be returned to the pool.
+    /// </para>
+    ///
+    /// <para>
+    /// The size of the pool created with this method is equal to the <see cref="IPooledRegistrationPolicy{TLimit}.MaximumRetained"/> value on the
+    /// <paramref name="poolPolicy"/>.
+    /// If more instances are requested than the pool size, those instances may not be returned to the pool, but will instead be disposed/discarded.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="registration">The registration.</param>
+    /// <param name="poolPolicy">A custom policy for controlling pool behaviour.</param>
+    /// <param name="lifetimeScopeTags">Tags applied to matching lifetime scopes.</param>
+    /// <returns>The registration builder.</returns>
+    public static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle>
+           PooledInstancePerMatchingLifetimeScope<TLimit, TActivatorData, TSingleRegistrationStyle>(
+               this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+               IPooledRegistrationPolicy<TLimit> poolPolicy,
+               params object[] lifetimeScopeTags)
+           where TSingleRegistrationStyle : SingleRegistrationStyle
+           where TActivatorData : IConcreteActivatorData
+           where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            RegisterPooled(registration, poolPolicy, lifetimeScopeTags);
-
-            return registration;
+            throw new ArgumentNullException(nameof(registration));
         }
 
-        private static void RegisterPooled<TLimit, TActivatorData, TSingleRegistrationStyle>(
-            IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
-            IPooledRegistrationPolicy<TLimit> registrationPolicy,
-            object[]? tags)
-            where TSingleRegistrationStyle : SingleRegistrationStyle
-            where TActivatorData : IConcreteActivatorData
-            where TLimit : class
+        RegisterPooled(registration, poolPolicy, lifetimeScopeTags);
+
+        return registration;
+    }
+
+    private static void RegisterPooled<TLimit, TActivatorData, TSingleRegistrationStyle>(
+        IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
+        IPooledRegistrationPolicy<TLimit> registrationPolicy,
+        object[]? tags)
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+        where TActivatorData : IConcreteActivatorData
+        where TLimit : class
+    {
+        if (registration == null)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            // Mark the lifetime appropriately.
-            var regData = registration.RegistrationData;
-
-            regData.Lifetime = new PooledLifetime();
-            regData.Sharing = InstanceSharing.None;
-
-            var callback = regData.DeferredCallback;
-
-            if (callback is null)
-            {
-                throw new NotSupportedException(RegistrationExtensionsResources.RequiresCallbackContainer);
-            }
-
-            if (registration.ActivatorData.Activator is ProvidedInstanceActivator)
-            {
-                // Can't use provided instance activators with pooling (because it would try to repeatedly activate).
-                throw new NotSupportedException(RegistrationExtensionsResources.CannotUseProvidedInstances);
-            }
-
-            var original = callback.Callback;
-
-            Action<IComponentRegistryBuilder> newCallback = registry =>
-            {
-                // Only do the additional registrations if we are still using a PooledLifetime.
-                if (!(regData.Lifetime is PooledLifetime))
-                {
-                    original(registry);
-                    return;
-                }
-
-                var pooledInstanceService = new UniqueService();
-
-                var instanceActivator = registration.ActivatorData.Activator;
-
-                if (registration.ResolvePipeline.Middleware.Any(c => c is CoreEventMiddleware ev && ev.EventType == ResolveEventType.OnRelease))
-                {
-                    // OnRelease shouldn't be used with pooled instances, because if a policy chooses not to return them to the pool,
-                    // the Disposal will be fired, not the OnRelease call; this means that OnRelease wouldn't fire until the container is disposed,
-                    // which is not what we want.
-                    throw new NotSupportedException(RegistrationExtensionsResources.OnReleaseNotSupported);
-                }
-
-                // First, we going to create a pooled instance activator, that will be resolved when we want to
-                // **actually** resolve a new instance (during 'Create').
-                // The instances themselves are owned by the pool, and will be disposed when the pool disposes
-                // (or when the instance is not returned to the pool).
-                var pooledInstanceRegistration = new ComponentRegistration(
-                    Guid.NewGuid(),
-                    instanceActivator,
-                    RootScopeLifetime.Instance,
-                    InstanceSharing.None,
-                    InstanceOwnership.ExternallyOwned,
-                    registration.ResolvePipeline,
-                    new[] { pooledInstanceService },
-                    new Dictionary<string, object?>());
-
-                registry.Register(pooledInstanceRegistration);
-
-                var poolService = new PoolService(pooledInstanceRegistration);
-
-                var poolRegistration = new ComponentRegistration(
-                    Guid.NewGuid(),
-                    new PoolActivator<TLimit>(pooledInstanceService, registrationPolicy),
-                    RootScopeLifetime.Instance,
-                    InstanceSharing.Shared,
-                    InstanceOwnership.OwnedByLifetimeScope,
-                    new[] { poolService },
-                    new Dictionary<string, object?>());
-
-                registry.Register(poolRegistration);
-
-                var pooledGetLifetime = tags is null ? CurrentScopeLifetime.Instance : new MatchingScopeLifetime(tags);
-
-                // Next, create a new registration with a custom activator, that copies metadata and services from
-                // the original registration. This registration will access the pool and return an instance from it.
-                var poolGetRegistration = new ComponentRegistration(
-                    Guid.NewGuid(),
-                    new PoolGetActivator<TLimit>(poolService, registrationPolicy),
-                    pooledGetLifetime,
-                    InstanceSharing.Shared,
-                    InstanceOwnership.OwnedByLifetimeScope,
-                    regData.Services,
-                    regData.Metadata);
-
-                registry.Register(poolGetRegistration);
-
-                // Finally, add a service pipeline stage to just before the sharing middleware, for each supported service, to extract the pooled instance from the pool instance container.
-                foreach (var srv in regData.Services)
-                {
-                    registry.RegisterServiceMiddleware(srv, new PooledInstanceUnpackMiddleware<TLimit>(), MiddlewareInsertionMode.StartOfPhase);
-                }
-            };
-
-            callback.Callback = newCallback;
+            throw new ArgumentNullException(nameof(registration));
         }
+
+        // Mark the lifetime appropriately.
+        var regData = registration.RegistrationData;
+
+        regData.Lifetime = new PooledLifetime();
+        regData.Sharing = InstanceSharing.None;
+
+        var callback = regData.DeferredCallback ?? throw new NotSupportedException(RegistrationExtensionsResources.RequiresCallbackContainer);
+
+        if (registration.ActivatorData.Activator is ProvidedInstanceActivator)
+        {
+            // Can't use provided instance activators with pooling (because it would try to repeatedly activate).
+            throw new NotSupportedException(RegistrationExtensionsResources.CannotUseProvidedInstances);
+        }
+
+        var original = callback.Callback;
+
+        Action<IComponentRegistryBuilder> newCallback = registry =>
+        {
+            // Only do the additional registrations if we are still using a PooledLifetime.
+            if (!(regData.Lifetime is PooledLifetime))
+            {
+                original(registry);
+                return;
+            }
+
+            var pooledInstanceService = new UniqueService();
+
+            var instanceActivator = registration.ActivatorData.Activator;
+
+            if (registration.ResolvePipeline.Middleware.Any(c => c is CoreEventMiddleware ev && ev.EventType == ResolveEventType.OnRelease))
+            {
+                // OnRelease shouldn't be used with pooled instances, because if a policy chooses not to return them to the pool,
+                // the Disposal will be fired, not the OnRelease call; this means that OnRelease wouldn't fire until the container is disposed,
+                // which is not what we want.
+                throw new NotSupportedException(RegistrationExtensionsResources.OnReleaseNotSupported);
+            }
+
+            // First, we going to create a pooled instance activator, that will be resolved when we want to
+            // **actually** resolve a new instance (during 'Create').
+            // The instances themselves are owned by the pool, and will be disposed when the pool disposes
+            // (or when the instance is not returned to the pool).
+            var pooledInstanceRegistration = new ComponentRegistration(
+                Guid.NewGuid(),
+                instanceActivator,
+                RootScopeLifetime.Instance,
+                InstanceSharing.None,
+                InstanceOwnership.ExternallyOwned,
+                registration.ResolvePipeline,
+                new[] { pooledInstanceService },
+                new Dictionary<string, object?>());
+
+            registry.Register(pooledInstanceRegistration);
+
+            var poolService = new PoolService(pooledInstanceRegistration);
+
+            var poolRegistration = new ComponentRegistration(
+                Guid.NewGuid(),
+                new PoolActivator<TLimit>(pooledInstanceService, registrationPolicy),
+                RootScopeLifetime.Instance,
+                InstanceSharing.Shared,
+                InstanceOwnership.OwnedByLifetimeScope,
+                new[] { poolService },
+                new Dictionary<string, object?>());
+
+            registry.Register(poolRegistration);
+
+            var pooledGetLifetime = tags is null ? CurrentScopeLifetime.Instance : new MatchingScopeLifetime(tags);
+
+            // Next, create a new registration with a custom activator, that copies metadata and services from
+            // the original registration. This registration will access the pool and return an instance from it.
+            var poolGetRegistration = new ComponentRegistration(
+                Guid.NewGuid(),
+                new PoolGetActivator<TLimit>(poolService, registrationPolicy),
+                pooledGetLifetime,
+                InstanceSharing.Shared,
+                InstanceOwnership.OwnedByLifetimeScope,
+                regData.Services,
+                regData.Metadata);
+
+            registry.Register(poolGetRegistration);
+
+            // Finally, add a service pipeline stage to just before the sharing middleware, for each supported service, to extract the pooled instance from the pool instance container.
+            foreach (var srv in regData.Services)
+            {
+                registry.RegisterServiceMiddleware(srv, new PooledInstanceUnpackMiddleware<TLimit>(), MiddlewareInsertionMode.StartOfPhase);
+            }
+        };
+
+        callback.Callback = newCallback;
     }
 }

--- a/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
+++ b/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -17,5 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Autofac.Pooling\Autofac.Pooling.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/test/Autofac.Pooling.Test/ConcurrencyTests.cs
+++ b/test/Autofac.Pooling.Test/ConcurrencyTests.cs
@@ -8,81 +8,80 @@ using Autofac.Core;
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class ConcurrencyTests
 {
-    public class ConcurrencyTests
+    [Fact]
+    public async Task CanUsePoolConcurrently()
     {
-        [Fact]
-        public async Task CanUsePoolConcurrently()
+        var builder = new ContainerBuilder();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>()
+                                               .PooledInstancePerLifetimeScope();
+
+        var container = builder.Build();
+
+        await Task.WhenAll(Enumerable.Range(0, 2000).Select(i => Task.Run(() =>
         {
-            var builder = new ContainerBuilder();
+            using var scope = container.BeginLifetimeScope();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>()
-                                                   .PooledInstancePerLifetimeScope();
+            scope.Resolve<IPooledService>();
+        })));
 
-            var container = builder.Build();
+        container.Dispose();
+    }
 
-            await Task.WhenAll(Enumerable.Range(0, 2000).Select(i => Task.Run(() =>
-            {
-                using var scope = container.BeginLifetimeScope();
+    [Fact]
+    public async Task CanUsePoolConcurrentlyWithCustomPolicyToBlockOnMaxUsage()
+    {
+        var builder = new ContainerBuilder();
 
-                scope.Resolve<IPooledService>();
-            })));
+        var blockingPolicy = new BlockingPolicy<PooledComponent>(4);
 
-            container.Dispose();
+        builder.RegisterType<PooledComponent>().As<IPooledService>()
+                                               .PooledInstancePerLifetimeScope(blockingPolicy);
+
+        var container = builder.Build();
+
+        await Task.WhenAll(Enumerable.Range(0, 10000).Select(i => Task.Run(() =>
+        {
+            using var scope = container.BeginLifetimeScope();
+
+            scope.Resolve<IPooledService>();
+
+            Assert.InRange(blockingPolicy.InUseCount, 1, 4);
+        })));
+
+        container.Dispose();
+    }
+
+    private class BlockingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
+        where TLimit : class
+    {
+        private readonly SemaphoreSlim _semaphore;
+
+        public BlockingPolicy(int maxConcurrentInstances) : base(maxConcurrentInstances)
+        {
+            _semaphore = new SemaphoreSlim(maxConcurrentInstances);
         }
 
-        [Fact]
-        public async Task CanUsePoolConcurrentlyWithCustomPolicyToBlockOnMaxUsage()
+        public int InUseCount => MaximumRetained - _semaphore.CurrentCount;
+
+        public override TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
         {
-            var builder = new ContainerBuilder();
+            _semaphore.Wait();
 
-            var blockingPolicy = new BlockingPolicy<PooledComponent>(4);
+            Assert.InRange(_semaphore.CurrentCount, 0, MaximumRetained);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>()
-                                                   .PooledInstancePerLifetimeScope(blockingPolicy);
-
-            var container = builder.Build();
-
-            await Task.WhenAll(Enumerable.Range(0, 10000).Select(i => Task.Run(() =>
-            {
-                using var scope = container.BeginLifetimeScope();
-
-                scope.Resolve<IPooledService>();
-
-                Assert.InRange(blockingPolicy.InUseCount, 1, 4);
-            })));
-
-            container.Dispose();
+            return base.Get(context, parameters, getFromPool);
         }
 
-        private class BlockingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
-            where TLimit : class
+        public override bool Return(TLimit pooledObject)
         {
-            private readonly SemaphoreSlim _semaphore;
+            _semaphore.Release();
 
-            public BlockingPolicy(int maxConcurrentInstances) : base(maxConcurrentInstances)
-            {
-                _semaphore = new SemaphoreSlim(maxConcurrentInstances);
-            }
-
-            public int InUseCount => MaximumRetained - _semaphore.CurrentCount;
-
-            public override TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
-            {
-                _semaphore.Wait();
-
-                Assert.InRange(_semaphore.CurrentCount, 0, MaximumRetained);
-
-                return base.Get(context, parameters, getFromPool);
-            }
-
-            public override bool Return(TLimit pooledObject)
-            {
-                _semaphore.Release();
-
-                return base.Return(pooledObject);
-            }
+            return base.Return(pooledObject);
         }
     }
 }

--- a/test/Autofac.Pooling.Test/DisposableTests.cs
+++ b/test/Autofac.Pooling.Test/DisposableTests.cs
@@ -2,92 +2,91 @@
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class DisposableTests
 {
-    public class DisposableTests
+    [Fact]
+    public void DisposableRegistrationsAreNotDisposedWhenReturnedToThePool()
     {
-        [Fact]
-        public void DisposableRegistrationsAreNotDisposedWhenReturnedToThePool()
-        {
-            var builder = new ContainerBuilder();
+        var builder = new ContainerBuilder();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
 
-            var container = builder.Build();
+        var container = builder.Build();
 
-            var pooled = container.Resolve<Owned<IPooledService>>();
+        var pooled = container.Resolve<Owned<IPooledService>>();
 
-            var pooledInstance = pooled.Value;
+        var pooledInstance = pooled.Value;
 
-            Assert.Equal(0, pooledInstance.DisposeCalled);
+        Assert.Equal(0, pooledInstance.DisposeCalled);
 
-            // Dispose puts it back in the pool.
-            pooled.Dispose();
+        // Dispose puts it back in the pool.
+        pooled.Dispose();
 
-            // Returned, but not disposed.
-            Assert.Equal(1, pooledInstance.ReturnCalled);
-            Assert.Equal(0, pooledInstance.DisposeCalled);
-        }
+        // Returned, but not disposed.
+        Assert.Equal(1, pooledInstance.ReturnCalled);
+        Assert.Equal(0, pooledInstance.DisposeCalled);
+    }
 
-        [Fact]
-        public void DisposableRegistrationsDisposedWhenContainerIsDisposed()
-        {
-            var builder = new ContainerBuilder();
+    [Fact]
+    public void DisposableRegistrationsDisposedWhenContainerIsDisposed()
+    {
+        var builder = new ContainerBuilder();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
 
-            var container = builder.Build();
+        var container = builder.Build();
 
-            var pooled = container.Resolve<Owned<IPooledService>>();
+        var pooled = container.Resolve<Owned<IPooledService>>();
 
-            var pooledInstance = pooled.Value;
+        var pooledInstance = pooled.Value;
 
-            // Dispose puts it back in the pool.
-            pooled.Dispose();
+        // Dispose puts it back in the pool.
+        pooled.Dispose();
 
-            Assert.Equal(0, pooledInstance.DisposeCalled);
+        Assert.Equal(0, pooledInstance.DisposeCalled);
 
-            container.Dispose();
+        container.Dispose();
 
-            Assert.Equal(1, pooledInstance.DisposeCalled);
-        }
+        Assert.Equal(1, pooledInstance.DisposeCalled);
+    }
 
-        [Fact]
-        public void DisposableRegistrationsDisposedWhenMaximumRetainedExceeded()
-        {
-            var builder = new ContainerBuilder();
+    [Fact]
+    public void DisposableRegistrationsDisposedWhenMaximumRetainedExceeded()
+    {
+        var builder = new ContainerBuilder();
 
-            // Only retain 1 instance in the pool.
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(1);
+        // Only retain 1 instance in the pool.
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(1);
 
-            var container = builder.Build();
+        var container = builder.Build();
 
-            var pooled1 = container.Resolve<Owned<IPooledService>>();
+        var pooled1 = container.Resolve<Owned<IPooledService>>();
 
-            var pooledInstance1 = pooled1.Value;
+        var pooledInstance1 = pooled1.Value;
 
-            var pooled2 = container.Resolve<Owned<IPooledService>>();
+        var pooled2 = container.Resolve<Owned<IPooledService>>();
 
-            var pooledInstance2 = pooled2.Value;
+        var pooledInstance2 = pooled2.Value;
 
-            // Dispose puts it back in the pool.
-            pooled1.Dispose();
+        // Dispose puts it back in the pool.
+        pooled1.Dispose();
 
-            // Pooled 2 will not go back in the pool because we have a max capacity of 1.
-            // So it's disposed immediately.
-            pooled2.Dispose();
+        // Pooled 2 will not go back in the pool because we have a max capacity of 1.
+        // So it's disposed immediately.
+        pooled2.Dispose();
 
-            Assert.Equal(0, pooledInstance1.DisposeCalled);
+        Assert.Equal(0, pooledInstance1.DisposeCalled);
 
-            Assert.Equal(1, pooledInstance2.ReturnCalled);
-            Assert.Equal(1, pooledInstance2.DisposeCalled);
+        Assert.Equal(1, pooledInstance2.ReturnCalled);
+        Assert.Equal(1, pooledInstance2.DisposeCalled);
 
-            // When the container is disposed, the pooled instance is disposed, but nothing
-            // happens to the not-pooled instance.
-            container.Dispose();
+        // When the container is disposed, the pooled instance is disposed, but nothing
+        // happens to the not-pooled instance.
+        container.Dispose();
 
-            Assert.Equal(1, pooledInstance1.DisposeCalled);
-            Assert.Equal(1, pooledInstance2.DisposeCalled);
-        }
+        Assert.Equal(1, pooledInstance1.DisposeCalled);
+        Assert.Equal(1, pooledInstance2.DisposeCalled);
     }
 }

--- a/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
+++ b/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
@@ -5,251 +5,250 @@ using Autofac.Features.OwnedInstances;
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class ImplicitRelationshipTests
 {
-    public class ImplicitRelationshipTests
+    [Fact]
+    public void CanResolveOwnedInstance()
     {
-        [Fact]
-        public void CanResolveOwnedInstance()
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope()
+            .OnActivated(args => activateCounter++);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var owned1 = scope1.Resolve<Owned<IPooledService>>();
 
-            var activateCounter = 0;
+            var owned2 = scope1.Resolve<Owned<IPooledService>>();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope()
-                .OnActivated(args => activateCounter++);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var owned1 = scope1.Resolve<Owned<IPooledService>>();
-
-                var owned2 = scope1.Resolve<Owned<IPooledService>>();
-
-                // 2 instance per owned should have been activated.
-                Assert.Equal(2, activateCounter);
-
-                // Disposing of the owned returns to the pool.
-                owned1.Dispose();
-                owned2.Dispose();
-            }
-
-            container.Dispose();
-        }
-
-        [Fact]
-        public void CanResolveMetaInstance()
-        {
-            var builder = new ContainerBuilder();
-
-            var activateCounter = 0;
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope()
-                .OnActivated(args => activateCounter++)
-                .WithMetadata("key", "value");
-
-            var container = builder.Build();
-
-            var scope1 = container.BeginLifetimeScope();
-            var meta1 = scope1.Resolve<Meta<IPooledService>>();
-
-            Assert.Equal("value", meta1.Metadata["key"]);
-
-            var scope2 = container.BeginLifetimeScope();
-            var meta2 = scope2.Resolve<Meta<IPooledService>>();
-
-            Assert.Equal("value", meta2.Metadata["key"]);
-
+            // 2 instance per owned should have been activated.
             Assert.Equal(2, activateCounter);
 
-            scope1.Dispose();
-            scope2.Dispose();
-
-            container.Dispose();
+            // Disposing of the owned returns to the pool.
+            owned1.Dispose();
+            owned2.Dispose();
         }
 
-        [Fact]
-        public void CanResolveLazyInstance()
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveMetaInstance()
+    {
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope()
+            .OnActivated(args => activateCounter++)
+            .WithMetadata("key", "value");
+
+        var container = builder.Build();
+
+        var scope1 = container.BeginLifetimeScope();
+        var meta1 = scope1.Resolve<Meta<IPooledService>>();
+
+        Assert.Equal("value", meta1.Metadata["key"]);
+
+        var scope2 = container.BeginLifetimeScope();
+        var meta2 = scope2.Resolve<Meta<IPooledService>>();
+
+        Assert.Equal("value", meta2.Metadata["key"]);
+
+        Assert.Equal(2, activateCounter);
+
+        scope1.Dispose();
+        scope2.Dispose();
+
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveLazyInstance()
+    {
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
+            .OnActivated(args => activateCounter++);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var lazy = scope1.Resolve<Lazy<IPooledService>>();
 
-            var activateCounter = 0;
-
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
-                .OnActivated(args => activateCounter++);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var lazy = scope1.Resolve<Lazy<IPooledService>>();
-
-                // Not activated yet.
-                Assert.Equal(0, activateCounter);
-                Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-                // Access the value.
-                Assert.NotNull(lazy.Value);
-
-                // Now it's activated.
-                Assert.Equal(1, activateCounter);
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
+            // Not activated yet.
+            Assert.Equal(0, activateCounter);
             Assert.Equal(0, trackingPolicy.OutOfPoolCount);
 
-            using (var scope2 = container.BeginLifetimeScope())
-            {
-                var lazy = scope2.Resolve<Lazy<IPooledService>>();
+            // Access the value.
+            Assert.NotNull(lazy.Value);
 
-                // Access the value.
-                Assert.NotNull(lazy.Value);
-
-                // No increase in activated count, should come from pool.
-                Assert.Equal(1, activateCounter);
-
-                // Out of pool count goes up.
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-            container.Dispose();
+            // Now it's activated.
+            Assert.Equal(1, activateCounter);
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
         }
 
-        [Fact]
-        public void CanResolveFuncInstance()
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        using (var scope2 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var lazy = scope2.Resolve<Lazy<IPooledService>>();
 
-            var activateCounter = 0;
+            // Access the value.
+            Assert.NotNull(lazy.Value);
 
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+            // No increase in activated count, should come from pool.
+            Assert.Equal(1, activateCounter);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
-                .OnActivated(args => activateCounter++);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var callback = scope1.Resolve<Func<IPooledService>>();
-
-                // Not activated yet.
-                Assert.Equal(0, activateCounter);
-                Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-                // Access the value.
-                Assert.NotNull(callback());
-
-                // Now it's activated.
-                Assert.Equal(1, activateCounter);
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-
-                // Access the value (will use the shared value).
-                Assert.NotNull(callback());
-
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-            container.Dispose();
+            // Out of pool count goes up.
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
         }
 
-        [Fact]
-        public void CanResolveCollectionOfPooledAndNonPooled()
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveFuncInstance()
+    {
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
+            .OnActivated(args => activateCounter++);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var callback = scope1.Resolve<Func<IPooledService>>();
 
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
-            builder.RegisterType<OtherPooledComponent>().As<IPooledService>().InstancePerLifetimeScope();
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var set = scope1.Resolve<IList<IPooledService>>();
-
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-
-                Assert.IsType<PooledComponent>(set[0]);
-                Assert.IsType<OtherPooledComponent>(set[1]);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
+            // Not activated yet.
+            Assert.Equal(0, activateCounter);
             Assert.Equal(0, trackingPolicy.OutOfPoolCount);
 
-            container.Dispose();
+            // Access the value.
+            Assert.NotNull(callback());
+
+            // Now it's activated.
+            Assert.Equal(1, activateCounter);
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+
+            // Access the value (will use the shared value).
+            Assert.NotNull(callback());
+
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
         }
 
-        [Fact]
-        public void CanResolveCollectionOfTwoDifferentPoolsOfSameService()
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveCollectionOfPooledAndNonPooled()
+    {
+        var builder = new ContainerBuilder();
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
+        builder.RegisterType<OtherPooledComponent>().As<IPooledService>().InstancePerLifetimeScope();
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var set = scope1.Resolve<IList<IPooledService>>();
 
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-            var otherTrackingPolicy = new PoolTrackingPolicy<OtherPooledComponent>();
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
-            builder.RegisterType<OtherPooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(otherTrackingPolicy);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var set = scope1.Resolve<IList<IPooledService>>();
-
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-                Assert.Equal(1, otherTrackingPolicy.OutOfPoolCount);
-
-                Assert.IsType<PooledComponent>(set[0]);
-                Assert.IsType<OtherPooledComponent>(set[1]);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-            Assert.Equal(0, otherTrackingPolicy.OutOfPoolCount);
-
-            container.Dispose();
+            Assert.IsType<PooledComponent>(set[0]);
+            Assert.IsType<OtherPooledComponent>(set[1]);
         }
 
-        [Fact]
-        public void CanResolveCollectionOfTwoDifferentPoolsOfSameLimitType()
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveCollectionOfTwoDifferentPoolsOfSameService()
+    {
+        var builder = new ContainerBuilder();
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+        var otherTrackingPolicy = new PoolTrackingPolicy<OtherPooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
+        builder.RegisterType<OtherPooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(otherTrackingPolicy);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var set = scope1.Resolve<IList<IPooledService>>();
 
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-            var otherTrackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+            Assert.Equal(1, otherTrackingPolicy.OutOfPoolCount);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(otherTrackingPolicy);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                var set = scope1.Resolve<IList<IPooledService>>();
-
-                // The important point is that each pool goes up by one, meaning that we can track different pools
-                // for the same limit type.
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-                Assert.Equal(1, otherTrackingPolicy.OutOfPoolCount);
-            }
-
-            // Lifetime scope dispose puts it back in the pool.
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-            Assert.Equal(0, otherTrackingPolicy.OutOfPoolCount);
-
-            container.Dispose();
+            Assert.IsType<PooledComponent>(set[0]);
+            Assert.IsType<OtherPooledComponent>(set[1]);
         }
+
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+        Assert.Equal(0, otherTrackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanResolveCollectionOfTwoDifferentPoolsOfSameLimitType()
+    {
+        var builder = new ContainerBuilder();
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+        var otherTrackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy);
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(otherTrackingPolicy);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
+        {
+            var set = scope1.Resolve<IList<IPooledService>>();
+
+            // The important point is that each pool goes up by one, meaning that we can track different pools
+            // for the same limit type.
+            Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+            Assert.Equal(1, otherTrackingPolicy.OutOfPoolCount);
+        }
+
+        // Lifetime scope dispose puts it back in the pool.
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+        Assert.Equal(0, otherTrackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
     }
 }

--- a/test/Autofac.Pooling.Test/LifetimeScopeTests.cs
+++ b/test/Autofac.Pooling.Test/LifetimeScopeTests.cs
@@ -2,124 +2,123 @@
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class LifetimeScopeTests
 {
-    public class LifetimeScopeTests
+    [Fact]
+    public void EachNestedScopeGetsOwnInstanceFromPool()
     {
-        [Fact]
-        public void EachNestedScopeGetsOwnInstanceFromPool()
+        var builder = new ContainerBuilder();
+
+        var tracking = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(tracking);
+
+        var container = builder.Build();
+
+        using (var scope = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var outerInstance = scope.Resolve<IPooledService>();
 
-            var tracking = new PoolTrackingPolicy<PooledComponent>();
+            Assert.Equal(1, tracking.OutOfPoolCount);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(tracking);
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
+            using (var innerScope = scope.BeginLifetimeScope())
             {
-                var outerInstance = scope.Resolve<IPooledService>();
+                var innerInstance = innerScope.Resolve<IPooledService>();
 
-                Assert.Equal(1, tracking.OutOfPoolCount);
+                Assert.Equal(2, tracking.OutOfPoolCount);
 
-                using (var innerScope = scope.BeginLifetimeScope())
-                {
-                    var innerInstance = innerScope.Resolve<IPooledService>();
-
-                    Assert.Equal(2, tracking.OutOfPoolCount);
-
-                    Assert.NotSame(outerInstance, innerInstance);
-                }
-
-                Assert.Equal(1, tracking.OutOfPoolCount);
+                Assert.NotSame(outerInstance, innerInstance);
             }
 
-            Assert.Equal(0, tracking.OutOfPoolCount);
+            Assert.Equal(1, tracking.OutOfPoolCount);
         }
 
-        [Fact]
-        public void MatchingScopeSharesPooledInstanceWithNestedScopes()
+        Assert.Equal(0, tracking.OutOfPoolCount);
+    }
+
+    [Fact]
+    public void MatchingScopeSharesPooledInstanceWithNestedScopes()
+    {
+        var builder = new ContainerBuilder();
+
+        var tracking = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerMatchingLifetimeScope(tracking, "tag");
+
+        var container = builder.Build();
+
+        using (var scope = container.BeginLifetimeScope("tag"))
         {
-            var builder = new ContainerBuilder();
+            var outerInstance = scope.Resolve<IPooledService>();
 
-            var tracking = new PoolTrackingPolicy<PooledComponent>();
+            Assert.Equal(1, tracking.OutOfPoolCount);
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerMatchingLifetimeScope(tracking, "tag");
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope("tag"))
+            using (var innerScope = scope.BeginLifetimeScope())
             {
-                var outerInstance = scope.Resolve<IPooledService>();
+                var innerInstance = innerScope.Resolve<IPooledService>();
 
                 Assert.Equal(1, tracking.OutOfPoolCount);
 
-                using (var innerScope = scope.BeginLifetimeScope())
-                {
-                    var innerInstance = innerScope.Resolve<IPooledService>();
-
-                    Assert.Equal(1, tracking.OutOfPoolCount);
-
-                    Assert.Same(outerInstance, innerInstance);
-                }
-
-                Assert.Equal(1, tracking.OutOfPoolCount);
+                Assert.Same(outerInstance, innerInstance);
             }
 
-            Assert.Equal(0, tracking.OutOfPoolCount);
+            Assert.Equal(1, tracking.OutOfPoolCount);
         }
 
-        [Fact]
-        public void MatchingScopeNotFoundErrorThrownWithPooledRegistration()
+        Assert.Equal(0, tracking.OutOfPoolCount);
+    }
+
+    [Fact]
+    public void MatchingScopeNotFoundErrorThrownWithPooledRegistration()
+    {
+        var builder = new ContainerBuilder();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerMatchingLifetimeScope("tag");
+
+        var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope();
+
+        Assert.Throws<DependencyResolutionException>(() => scope.Resolve<IPooledService>());
+    }
+
+    [Fact]
+    public void PoolCanBeOverriddenInNestedScope()
+    {
+        var builder = new ContainerBuilder();
+
+        var outerPolicy = new PoolTrackingPolicy<PooledComponent>();
+        var innerPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(outerPolicy);
+
+        var container = builder.Build();
+
+        using (var scope = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            var outerInstance = scope.Resolve<IPooledService>();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerMatchingLifetimeScope("tag");
+            Assert.Equal(1, outerPolicy.OutOfPoolCount);
 
-            var container = builder.Build();
-
-            using var scope = container.BeginLifetimeScope();
-
-            Assert.Throws<DependencyResolutionException>(() => scope.Resolve<IPooledService>());
-        }
-
-        [Fact]
-        public void PoolCanBeOverriddenInNestedScope()
-        {
-            var builder = new ContainerBuilder();
-
-            var outerPolicy = new PoolTrackingPolicy<PooledComponent>();
-            var innerPolicy = new PoolTrackingPolicy<PooledComponent>();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(outerPolicy);
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
+            using (var overrideScope = scope.BeginLifetimeScope(cfg =>
             {
-                var outerInstance = scope.Resolve<IPooledService>();
+                cfg.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(innerPolicy);
+            }))
+            {
+                var innerInstance = overrideScope.Resolve<IPooledService>();
 
                 Assert.Equal(1, outerPolicy.OutOfPoolCount);
+                Assert.Equal(1, innerPolicy.OutOfPoolCount);
 
-                using (var overrideScope = scope.BeginLifetimeScope(cfg =>
-                {
-                    cfg.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(innerPolicy);
-                }))
-                {
-                    var innerInstance = overrideScope.Resolve<IPooledService>();
-
-                    Assert.Equal(1, outerPolicy.OutOfPoolCount);
-                    Assert.Equal(1, innerPolicy.OutOfPoolCount);
-
-                    Assert.NotSame(outerInstance, innerInstance);
-                }
-
-                Assert.Equal(0, innerPolicy.OutOfPoolCount);
-                Assert.Equal(1, outerPolicy.OutOfPoolCount);
+                Assert.NotSame(outerInstance, innerInstance);
             }
 
-            Assert.Equal(0, outerPolicy.OutOfPoolCount);
+            Assert.Equal(0, innerPolicy.OutOfPoolCount);
+            Assert.Equal(1, outerPolicy.OutOfPoolCount);
         }
+
+        Assert.Equal(0, outerPolicy.OutOfPoolCount);
     }
 }

--- a/test/Autofac.Pooling.Test/PolicyTests.cs
+++ b/test/Autofac.Pooling.Test/PolicyTests.cs
@@ -5,190 +5,189 @@ using Autofac.Core;
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class PolicyTests
 {
-    public class PolicyTests
+    [Fact]
+    public void PolicyIsNotifiedAtCorrectPoints()
     {
-        [Fact]
-        public void PolicyIsNotifiedAtCorrectPoints()
-        {
-            var builder = new ContainerBuilder();
+        var builder = new ContainerBuilder();
 
-            var events = new List<string>();
+        var events = new List<string>();
 
-            var policy = new CustomPolicy<PooledComponent>(
-                (ctxt, param, getCallback) =>
-                {
-                    events.Add("get");
-                    return getCallback();
-                },
-                (instance) =>
-                {
-                    events.Add("return");
-                    return true;
-                });
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
-
-            var container = builder.Build();
-
-            using (var scope = container.BeginLifetimeScope())
+        var policy = new CustomPolicy<PooledComponent>(
+            (ctxt, param, getCallback) =>
             {
-                scope.Resolve<IPooledService>();
-            }
+                events.Add("get");
+                return getCallback();
+            },
+            (instance) =>
+            {
+                events.Add("return");
+                return true;
+            });
 
-            Assert.Equal(new[] { "get", "return" }, events);
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
+
+        var container = builder.Build();
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            scope.Resolve<IPooledService>();
         }
 
-        [Fact]
-        public void PolicyCanChooseNotToGetFromThePool()
-        {
-            var builder = new ContainerBuilder();
+        Assert.Equal(new[] { "get", "return" }, events);
+    }
 
-            var returnCalled = false;
+    [Fact]
+    public void PolicyCanChooseNotToGetFromThePool()
+    {
+        var builder = new ContainerBuilder();
 
-            var policy = new CustomPolicy<PooledComponent>(
-                (ctxt, param, getCallback) =>
-                {
-                    return new PooledComponent();
-                },
-                (instance) =>
-                {
-                    returnCalled = true;
-                    return true;
-                });
+        var returnCalled = false;
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
-
-            var container = builder.Build();
-
-            IPooledService pooledInstance;
-
-            using (var scope = container.BeginLifetimeScope())
+        var policy = new CustomPolicy<PooledComponent>(
+            (ctxt, param, getCallback) =>
             {
-                pooledInstance = scope.Resolve<IPooledService>();
+                return new PooledComponent();
+            },
+            (instance) =>
+            {
+                returnCalled = true;
+                return true;
+            });
 
-                Assert.Equal(0, pooledInstance.GetCalled);
-            }
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
 
-            Assert.Equal(0, pooledInstance.ReturnCalled);
-            Assert.Equal(1, pooledInstance.DisposeCalled);
-            Assert.False(returnCalled);
+        var container = builder.Build();
 
-            container.Dispose();
+        IPooledService pooledInstance;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            pooledInstance = scope.Resolve<IPooledService>();
+
+            Assert.Equal(0, pooledInstance.GetCalled);
         }
 
-        [Fact]
-        public void PolicyCanChooseNotToReturnToThePool()
-        {
-            var builder = new ContainerBuilder();
+        Assert.Equal(0, pooledInstance.ReturnCalled);
+        Assert.Equal(1, pooledInstance.DisposeCalled);
+        Assert.False(returnCalled);
 
-            var counter = 0;
+        container.Dispose();
+    }
 
-            var policy = new CustomPolicy<PooledComponent>(
-                (ctxt, param, getCallback) =>
-                {
-                    counter++;
-                    return getCallback();
-                },
-                (instance) =>
-                {
-                    counter--;
-                    return false;
-                });
+    [Fact]
+    public void PolicyCanChooseNotToReturnToThePool()
+    {
+        var builder = new ContainerBuilder();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
+        var counter = 0;
 
-            var container = builder.Build();
-
-            IPooledService pooledInstance;
-
-            using (var scope = container.BeginLifetimeScope())
+        var policy = new CustomPolicy<PooledComponent>(
+            (ctxt, param, getCallback) =>
             {
-                pooledInstance = scope.Resolve<IPooledService>();
+                counter++;
+                return getCallback();
+            },
+            (instance) =>
+            {
+                counter--;
+                return false;
+            });
 
-                Assert.Equal(1, counter);
-            }
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
 
-            Assert.Equal(0, counter);
-            Assert.Equal(1, pooledInstance.GetCalled);
-            Assert.Equal(1, pooledInstance.ReturnCalled);
-            Assert.Equal(1, pooledInstance.DisposeCalled);
+        var container = builder.Build();
 
-            container.Dispose();
+        IPooledService pooledInstance;
 
-            Assert.Equal(1, pooledInstance.DisposeCalled);
+        using (var scope = container.BeginLifetimeScope())
+        {
+            pooledInstance = scope.Resolve<IPooledService>();
+
+            Assert.Equal(1, counter);
         }
 
-        [Fact]
-        public void PolicyCanSeeParametersFromThePooledServiceResolve()
-        {
-            var builder = new ContainerBuilder();
+        Assert.Equal(0, counter);
+        Assert.Equal(1, pooledInstance.GetCalled);
+        Assert.Equal(1, pooledInstance.ReturnCalled);
+        Assert.Equal(1, pooledInstance.DisposeCalled);
 
-            List<Parameter> policyReceivedParameters = new List<Parameter>();
+        container.Dispose();
 
-            var policy = new CustomPolicy<PooledComponent>(
-                (ctxt, param, getCallback) =>
-                {
+        Assert.Equal(1, pooledInstance.DisposeCalled);
+    }
 
-                    policyReceivedParameters.AddRange(param);
+    [Fact]
+    public void PolicyCanSeeParametersFromThePooledServiceResolve()
+    {
+        var builder = new ContainerBuilder();
 
-                    return getCallback();
-                },
-                (instance) =>
-                {
-                    return false;
-                });
+        var policyReceivedParameters = new List<Parameter>();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
-
-            var container = builder.Build();
-
-            IPooledService pooledInstance;
-
-            using (var scope = container.BeginLifetimeScope())
+        var policy = new CustomPolicy<PooledComponent>(
+            (ctxt, param, getCallback) =>
             {
-                pooledInstance = scope.Resolve<IPooledService>(new NamedParameter("Val1", 123), new TypedParameter(typeof(int), 456));
-            }
 
-            Assert.Collection(policyReceivedParameters,
-                p =>
-                {
-                    Assert.Equal("Val1", (p as NamedParameter)?.Name);
-                },
-                p =>
-                {
-                    Assert.Equal(456, (p as TypedParameter)?.Value);
-                });
+                policyReceivedParameters.AddRange(param);
 
-            container.Dispose();
+                return getCallback();
+            },
+            (instance) =>
+            {
+                return false;
+            });
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(policy);
+
+        var container = builder.Build();
+
+        IPooledService pooledInstance;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            pooledInstance = scope.Resolve<IPooledService>(new NamedParameter("Val1", 123), new TypedParameter(typeof(int), 456));
         }
 
-        private class CustomPolicy<TLimit> : IPooledRegistrationPolicy<TLimit>
-            where TLimit : class
+        Assert.Collection(policyReceivedParameters,
+            p =>
+            {
+                Assert.Equal("Val1", (p as NamedParameter)?.Name);
+            },
+            p =>
+            {
+                Assert.Equal(456, (p as TypedParameter)?.Value);
+            });
+
+        container.Dispose();
+    }
+
+    private class CustomPolicy<TLimit> : IPooledRegistrationPolicy<TLimit>
+        where TLimit : class
+    {
+        private readonly Func<IComponentContext, IEnumerable<Parameter>, Func<TLimit>, TLimit> _get;
+        private readonly Func<TLimit, bool> _return;
+
+        public int MaximumRetained => 6;
+
+        public CustomPolicy(
+            Func<IComponentContext, IEnumerable<Parameter>, Func<TLimit>, TLimit> get,
+            Func<TLimit, bool> @return)
         {
-            private readonly Func<IComponentContext, IEnumerable<Parameter>, Func<TLimit>, TLimit> _get;
-            private readonly Func<TLimit, bool> _return;
+            _get = get;
+            _return = @return;
+        }
 
-            public int MaximumRetained => 6;
+        public TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
+        {
+            return _get(context, parameters, getFromPool);
+        }
 
-            public CustomPolicy(
-                Func<IComponentContext, IEnumerable<Parameter>, Func<TLimit>, TLimit> get,
-                Func<TLimit, bool> @return)
-            {
-                _get = get;
-                _return = @return;
-            }
-
-            public TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
-            {
-                return _get(context, parameters, getFromPool);
-            }
-
-            public bool Return(TLimit pooledObject)
-            {
-                return _return(pooledObject);
-            }
+        public bool Return(TLimit pooledObject)
+        {
+            return _return(pooledObject);
         }
     }
 }

--- a/test/Autofac.Pooling.Test/PooledComponentTests.cs
+++ b/test/Autofac.Pooling.Test/PooledComponentTests.cs
@@ -2,56 +2,55 @@
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class PooledComponentTests
 {
-    public class PooledComponentTests
+    [Fact]
+    public void PooledComponentNotifiedOfGetAndReturn()
     {
-        [Fact]
-        public void PooledComponentNotifiedOfGetAndReturn()
+        var builder = new ContainerBuilder();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
+
+        var container = builder.Build();
+
+        var pooled = container.Resolve<Owned<IPooledService>>();
+
+        var pooledInstance = pooled.Value;
+
+        Assert.Equal(1, pooledInstance.GetCalled);
+
+        // Dispose puts it back in the pool.
+        pooled.Dispose();
+
+        Assert.Equal(1, pooledInstance.ReturnCalled);
+    }
+
+    [Fact]
+    public void PooledComponentNotifiedOfGetAndReturnOnlyOnceInLifetimeScope()
+    {
+        var builder = new ContainerBuilder();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
+
+        var container = builder.Build();
+
+        IPooledService pooled;
+
+        using (var scope = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
+            pooled = scope.Resolve<IPooledService>();
 
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
+            Assert.Equal(1, pooled.GetCalled);
 
-            var container = builder.Build();
+            var secondPooled = scope.Resolve<IPooledService>();
 
-            var pooled = container.Resolve<Owned<IPooledService>>();
+            Assert.Same(pooled, secondPooled);
 
-            var pooledInstance = pooled.Value;
-
-            Assert.Equal(1, pooledInstance.GetCalled);
-
-            // Dispose puts it back in the pool.
-            pooled.Dispose();
-
-            Assert.Equal(1, pooledInstance.ReturnCalled);
+            Assert.Equal(1, pooled.GetCalled);
         }
 
-        [Fact]
-        public void PooledComponentNotifiedOfGetAndReturnOnlyOnceInLifetimeScope()
-        {
-            var builder = new ContainerBuilder();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope();
-
-            var container = builder.Build();
-
-            IPooledService pooled;
-
-            using (var scope = container.BeginLifetimeScope())
-            {
-                pooled = scope.Resolve<IPooledService>();
-
-                Assert.Equal(1, pooled.GetCalled);
-
-                var secondPooled = scope.Resolve<IPooledService>();
-
-                Assert.Same(pooled, secondPooled);
-
-                Assert.Equal(1, pooled.GetCalled);
-            }
-
-            Assert.Equal(1, pooled.ReturnCalled);
-        }
+        Assert.Equal(1, pooled.ReturnCalled);
     }
 }

--- a/test/Autofac.Pooling.Test/PoolingTests.cs
+++ b/test/Autofac.Pooling.Test/PoolingTests.cs
@@ -1,113 +1,112 @@
 ﻿using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Tests
+namespace Autofac.Pooling.Tests;
+
+public class PoolingTest
 {
-    public class PoolingTest
+    [Fact]
+    public void CanRegisterPooledService()
     {
-        [Fact]
-        public void CanRegisterPooledService()
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        // Register a pooled instance. OnActivated only fires when actual instances of the component are created.
+        builder.RegisterType<PooledComponent>().As<IPooledService>()
+                                               .PooledInstancePerLifetimeScope()
+                                               .OnActivated(args => activateCounter++);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
-
-            var activateCounter = 0;
-
-            // Register a pooled instance. OnActivated only fires when actual instances of the component are created.
-            builder.RegisterType<PooledComponent>().As<IPooledService>()
-                                                   .PooledInstancePerLifetimeScope()
-                                                   .OnActivated(args => activateCounter++);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                scope1.Resolve<IPooledService>();
-            }
-
-            using (var scope2 = container.BeginLifetimeScope())
-            {
-                scope2.Resolve<IPooledService>();
-            }
-
-            // Only 1 instance should have been activated, because we retrieved from the pool each time.
-            Assert.Equal(1, activateCounter);
-
-            // When we dispose of the container, our instances are disposed by the pool.
-            container.Dispose();
+            scope1.Resolve<IPooledService>();
         }
 
-        [Fact]
-        public void CanRegisterPooledServiceWithCustomPolicy()
+        using (var scope2 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
-
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>()
-                                                   .PooledInstancePerLifetimeScope(trackingPolicy);
-
-            var container = builder.Build();
-
-            using (var scope1 = container.BeginLifetimeScope())
-            {
-                Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-                scope1.Resolve<IPooledService>();
-
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-            }
-
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-            using (var scope2 = container.BeginLifetimeScope())
-            {
-                scope2.Resolve<IPooledService>();
-
-                Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-            }
-
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-            // After we dispose of the container, our instances are disposed.
-            container.Dispose();
+            scope2.Resolve<IPooledService>();
         }
 
-        [Fact]
-        public void MultipleActiveScopesIncreaseSizeOfPool()
+        // Only 1 instance should have been activated, because we retrieved from the pool each time.
+        Assert.Equal(1, activateCounter);
+
+        // When we dispose of the container, our instances are disposed by the pool.
+        container.Dispose();
+    }
+
+    [Fact]
+    public void CanRegisterPooledServiceWithCustomPolicy()
+    {
+        var builder = new ContainerBuilder();
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>()
+                                               .PooledInstancePerLifetimeScope(trackingPolicy);
+
+        var container = builder.Build();
+
+        using (var scope1 = container.BeginLifetimeScope())
         {
-            var builder = new ContainerBuilder();
-
-            var activateCounter = 0;
-
-            var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
-
-            builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
-                .OnActivated(args => activateCounter++);
-
-            var container = builder.Build();
-
             Assert.Equal(0, trackingPolicy.OutOfPoolCount);
 
-            var scope1 = container.BeginLifetimeScope();
             scope1.Resolve<IPooledService>();
 
             Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+        }
 
-            var scope2 = container.BeginLifetimeScope();
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        using (var scope2 = container.BeginLifetimeScope())
+        {
             scope2.Resolve<IPooledService>();
 
-            Assert.Equal(2, trackingPolicy.OutOfPoolCount);
-
-            Assert.Equal(2, activateCounter);
-            scope1.Dispose();
-
             Assert.Equal(1, trackingPolicy.OutOfPoolCount);
-
-            scope2.Dispose();
-
-            Assert.Equal(0, trackingPolicy.OutOfPoolCount);
-
-            container.Dispose();
         }
+
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        // After we dispose of the container, our instances are disposed.
+        container.Dispose();
+    }
+
+    [Fact]
+    public void MultipleActiveScopesIncreaseSizeOfPool()
+    {
+        var builder = new ContainerBuilder();
+
+        var activateCounter = 0;
+
+        var trackingPolicy = new PoolTrackingPolicy<PooledComponent>();
+
+        builder.RegisterType<PooledComponent>().As<IPooledService>().PooledInstancePerLifetimeScope(trackingPolicy)
+            .OnActivated(args => activateCounter++);
+
+        var container = builder.Build();
+
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        var scope1 = container.BeginLifetimeScope();
+        scope1.Resolve<IPooledService>();
+
+        Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+
+        var scope2 = container.BeginLifetimeScope();
+        scope2.Resolve<IPooledService>();
+
+        Assert.Equal(2, trackingPolicy.OutOfPoolCount);
+
+        Assert.Equal(2, activateCounter);
+        scope1.Dispose();
+
+        Assert.Equal(1, trackingPolicy.OutOfPoolCount);
+
+        scope2.Dispose();
+
+        Assert.Equal(0, trackingPolicy.OutOfPoolCount);
+
+        container.Dispose();
     }
 }

--- a/test/Autofac.Pooling.Test/RegistrationExtensionsTests.cs
+++ b/test/Autofac.Pooling.Test/RegistrationExtensionsTests.cs
@@ -3,39 +3,38 @@ using Autofac.Builder;
 using Autofac.Pooling.Tests.Shared;
 using Xunit;
 
-namespace Autofac.Pooling.Test
+namespace Autofac.Pooling.Test;
+
+public class RegistrationExtensionsTests
 {
-    public class RegistrationExtensionsTests
+    [Fact]
+    public void RequiresCallbackContainer()
     {
-        [Fact]
-        public void RequiresCallbackContainer()
-        {
-            // Manually create a registration builder, then call AsPooled
-            var regBuilder = RegistrationBuilder.ForType<PooledComponent>();
+        // Manually create a registration builder, then call AsPooled
+        var regBuilder = RegistrationBuilder.ForType<PooledComponent>();
 
-            Assert.Throws<NotSupportedException>(() => regBuilder.PooledInstancePerLifetimeScope());
-        }
+        Assert.Throws<NotSupportedException>(() => regBuilder.PooledInstancePerLifetimeScope());
+    }
 
-        [Fact]
-        public void NoProvidedInstances()
-        {
-            var builder = new ContainerBuilder();
+    [Fact]
+    public void NoProvidedInstances()
+    {
+        var builder = new ContainerBuilder();
 
-            var regBuilder = builder.RegisterInstance(new PooledComponent());
+        var regBuilder = builder.RegisterInstance(new PooledComponent());
 
-            Assert.Throws<NotSupportedException>(() => regBuilder.PooledInstancePerLifetimeScope());
-        }
+        Assert.Throws<NotSupportedException>(() => regBuilder.PooledInstancePerLifetimeScope());
+    }
 
-        [Fact]
-        public void OnReleaseNotCompatible()
-        {
-            var builder = new ContainerBuilder();
+    [Fact]
+    public void OnReleaseNotCompatible()
+    {
+        var builder = new ContainerBuilder();
 
-            builder.RegisterType<PooledComponent>()
-                   .PooledInstancePerLifetimeScope()
-                   .OnRelease(args => { });
+        builder.RegisterType<PooledComponent>()
+               .PooledInstancePerLifetimeScope()
+               .OnRelease(args => { });
 
-            Assert.Throws<NotSupportedException>(() => builder.Build());
-        }
+        Assert.Throws<NotSupportedException>(() => builder.Build());
     }
 }

--- a/test/Autofac.Pooling.Test/Shared/IPooledService.cs
+++ b/test/Autofac.Pooling.Test/Shared/IPooledService.cs
@@ -1,11 +1,19 @@
-﻿namespace Autofac.Pooling.Tests.Shared
+﻿namespace Autofac.Pooling.Tests.Shared;
+
+public interface IPooledService
 {
-    public interface IPooledService
+    int GetCalled
     {
-        int GetCalled { get; }
+        get;
+    }
 
-        int ReturnCalled { get; }
+    int ReturnCalled
+    {
+        get;
+    }
 
-        int DisposeCalled { get; }
+    int DisposeCalled
+    {
+        get;
     }
 }

--- a/test/Autofac.Pooling.Test/Shared/OtherPooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Shared/OtherPooledComponent.cs
@@ -1,11 +1,10 @@
-﻿namespace Autofac.Pooling.Tests.Shared
+﻿namespace Autofac.Pooling.Tests.Shared;
+
+public class OtherPooledComponent : IPooledService
 {
-    public class OtherPooledComponent : IPooledService
-    {
-        public int GetCalled => throw new System.NotImplementedException();
+    public int GetCalled => throw new System.NotImplementedException();
 
-        public int ReturnCalled => throw new System.NotImplementedException();
+    public int ReturnCalled => throw new System.NotImplementedException();
 
-        public int DisposeCalled => throw new System.NotImplementedException();
-    }
+    public int DisposeCalled => throw new System.NotImplementedException();
 }

--- a/test/Autofac.Pooling.Test/Shared/PoolTrackingPolicy.cs
+++ b/test/Autofac.Pooling.Test/Shared/PoolTrackingPolicy.cs
@@ -3,27 +3,26 @@ using System.Collections.Generic;
 using System.Threading;
 using Autofac.Core;
 
-namespace Autofac.Pooling.Tests.Shared
+namespace Autofac.Pooling.Tests.Shared;
+
+public class PoolTrackingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
+    where TLimit : class
 {
-    public class PoolTrackingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
-        where TLimit : class
+    private int _outOfPool;
+
+    public int OutOfPoolCount => _outOfPool;
+
+    public override TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
     {
-        private int _outOfPool;
+        Interlocked.Increment(ref _outOfPool);
 
-        public int OutOfPoolCount => _outOfPool;
+        return getFromPool();
+    }
 
-        public override TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
-        {
-            Interlocked.Increment(ref _outOfPool);
+    public override bool Return(TLimit pooledObject)
+    {
+        Interlocked.Decrement(ref _outOfPool);
 
-            return getFromPool();
-        }
-
-        public override bool Return(TLimit pooledObject)
-        {
-            Interlocked.Decrement(ref _outOfPool);
-
-            return base.Return(pooledObject);
-        }
+        return base.Return(pooledObject);
     }
 }

--- a/test/Autofac.Pooling.Test/Shared/PooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Shared/PooledComponent.cs
@@ -2,29 +2,37 @@
 using System.Collections.Generic;
 using Autofac.Core;
 
-namespace Autofac.Pooling.Tests.Shared
+namespace Autofac.Pooling.Tests.Shared;
+
+public class PooledComponent : IPooledService, IPooledComponent, IDisposable
 {
-    public class PooledComponent : IPooledService, IPooledComponent, IDisposable
+    public int GetCalled
     {
-        public int GetCalled { get; private set; }
+        get; private set;
+    }
 
-        public int ReturnCalled { get; private set; }
+    public int ReturnCalled
+    {
+        get; private set;
+    }
 
-        public int DisposeCalled { get; private set; }
+    public int DisposeCalled
+    {
+        get; private set;
+    }
 
-        public void OnGetFromPool(IComponentContext ctxt, IEnumerable<Parameter> parameters)
-        {
-            GetCalled++;
-        }
+    public void OnGetFromPool(IComponentContext ctxt, IEnumerable<Parameter> parameters)
+    {
+        GetCalled++;
+    }
 
-        public void OnReturnToPool()
-        {
-            ReturnCalled++;
-        }
+    public void OnReturnToPool()
+    {
+        ReturnCalled++;
+    }
 
-        public void Dispose()
-        {
-            DisposeCalled++;
-        }
+    public void Dispose()
+    {
+        DisposeCalled++;
     }
 }


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting
- Add proper file copyright headers
- Fix SA1616 missing return value documentation

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes