### PR TITLE
Remove Microsoft.CodeAnalysis.Analyzers (included in .NET 10 SDK)

### DIFF
--- a/src/Autofac.Pooling/Autofac.Pooling.csproj
+++ b/src/Autofac.Pooling/Autofac.Pooling.csproj
@@ -45,10 +45,6 @@
     <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Remove Microsoft.CodeAnalysis.Analyzers package reference since it's now bundled with the .NET 10 SDK

## Test plan
- [x] Build succeeds with zero warnings
- [x] All target frameworks build successfully