### PR TITLE
Add SonarAnalyzer.CSharp and tighten Roslyn analyzer rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+  "cSpell.words": [
+    "autofac"
+  ],
   "omnisharp.enableEditorConfigSupport": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
-    "autofac"
+    "autofac",
+    "xunit"
   ],
   "omnisharp.enableEditorConfigSupport": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,20 +2,8 @@
   "tasks": [
     {
       "args": [
-        "watch",
-        "run",
-        "${workspaceFolder}/test/Autofac.Pooling.Tests/Autofac.Pooling.Tests.csproj",
-        "/property:GenerateFullPaths=true",
-        "/consoleloggerparameters:NoSummary"
-      ],
-      "command": "dotnet",
-      "label": "watch",
-      "problemMatcher": "$msCompile",
-      "type": "process"
-    },
-    {
-      "args": [
         "build",
+        "Autofac.Pooling.sln",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-</Project>

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,6 +4,8 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
     <!-- Avoid excessive complexity (must be explicitly enabled). -->
@@ -44,6 +46,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - Autofac uses non-standard dispose patterns for container lifecycle. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -32,6 +32,8 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- "Sonar Way" rules to match SonarQube scans. -->
     <Rule Id="S107" Action="Warning" />
+    <!-- Do not use obsolete members - Autofac maintains deprecated APIs for backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1192" Action="Warning" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac source assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -12,22 +12,40 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <!-- Use ArgumentNullException.ThrowIfNull - not available in netstandard. -->
     <Rule Id="CA1510" Action="None" />
-    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - not available below net8.0. -->
     <Rule Id="CA1512" Action="None" />
-    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ObjectDisposedException.ThrowIf - not available below net8.0. -->
     <Rule Id="CA1513" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <!-- Change names to avoid reserved word overlaps - would break public API. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <!-- Cache a CompositeFormat - not available in netstandard. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <!-- Prefer generic overloads - conflicts with reflection work in Autofac. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- "Sonar Way" rules to match SonarQube scans. -->
+    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1192" Action="Warning" />
+    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S2259" Action="Warning" />
+    <Rule Id="S2583" Action="Warning" />
+    <Rule Id="S2589" Action="Warning" />
+    <!-- Verify reflection accessibility bypass - DI containers do extensive reflection by design. -->
+    <Rule Id="S3011" Action="None" />
+    <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
+    <Rule Id="S3267" Action="None" />
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <Rule Id="S6418" Action="Warning" />
+    <Rule Id="S6444" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -55,6 +55,8 @@
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
+    <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -42,6 +42,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Nested types should not be visible - test scenario classes use nested types extensively. -->
+    <Rule Id="CA1034" Action="None" />
     <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -23,6 +23,10 @@
     <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Internal class that appears to never be instantiated - false positives from DI. -->
+    <!-- Identifiers should not have incorrect suffix - test classes use Impl, Handler, etc. -->
+    <Rule Id="CA1711" Action="None" />
+    <!-- Property names should not match get methods - aggregate service tests intentionally test both. -->
+    <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
@@ -55,6 +59,8 @@
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
     <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <!-- Sections of code should not be commented out - test files may retain commented examples. -->
+    <Rule Id="S125" Action="None" />
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -39,6 +39,8 @@
     <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive in .NET Core. -->
+    <!-- Do not raise reserved exception types - tests use generic exceptions for simulation. -->
+    <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1031" Action="None" />
     <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
@@ -54,9 +56,9 @@
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
-    <!-- Remove unused private members - reflection tests need non-public members. -->
     <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
     <Rule Id="S1133" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />
@@ -80,6 +82,8 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - test dispose implementations are intentionally simplified. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,16 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
-    <Rule Id="CA1005" Action="Warning" />
-    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Don't catch general exceptions - test scenarios sometimes require it. -->
     <Rule Id="CA1031" Action="None" />
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
-    <Rule Id="CA1032" Action="None" />
-    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
-    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -20,36 +16,78 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
-    <Rule Id="CA1510" Action="None" />
-    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <!-- Make API types internal - causes problems with tests. -->
     <Rule Id="CA1515" Action="None" />
-    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
-    <Rule Id="CA1716" Action="None" />
-    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <!-- Internal class that appears to never be instantiated - false positives from DI. -->
     <Rule Id="CA1812" Action="None" />
-    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
-    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <!-- Mark members static - test methods may not access member data. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <!-- Use the LoggerMessage delegates - noise in tests, performance irrelevant. -->
+    <Rule Id="CA1848" Action="None" />
+    <!-- Seal internal types - unimportant in tests. -->
     <Rule Id="CA1852" Action="None" />
-    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <!-- Prefer static readonly fields over constant arrays - happens in test setup. -->
     <Rule Id="CA1861" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <!-- Cache a CompositeFormat - makes tests harder to read. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
+    <Rule Id="S1075" Action="None" />
+    <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <Rule Id="S1118" Action="None" />
+    <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
+    <Rule Id="S1215" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
+    <Rule Id="S1144" Action="None" />
+    <!-- Empty method bodies - test stubs often have no-op implementations. -->
+    <Rule Id="S1186" Action="None" />
+    <!-- Remove unused method parameters - reflection tests declare parameters not used in the body. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove empty class - test stubs for DI resolution don't need implementation. -->
+    <Rule Id="S2094" Action="None" />
+    <!-- Make member static - test fixture members may not access instance data. -->
+    <Rule Id="S2325" Action="None" />
+    <!-- Remove unused type parameters - used in reflection testing. -->
+    <Rule Id="S2326" Action="None" />
+    <!-- Write-only properties - reflection tests verify property setter behavior. -->
+    <Rule Id="S2376" Action="None" />
+    <!-- Classes with only private constructors - reflection tests verify inaccessible constructors. -->
+    <Rule Id="S3453" Action="None" />
+    <!-- Remove unassigned auto-property - reflection tests verify non-public property behavior. -->
+    <Rule Id="S3459" Action="None" />
+    <!-- Complete the TODO - acceptable in tests for backlog items. -->
+    <Rule Id="S1135" Action="None" />
+    <!-- Make instance property static - false positives in data/document types. -->
+    <Rule Id="S2335" Action="None" />
+    <!-- Cognitive complexity (must be explicitly enabled). -->
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->
+    <Rule Id="S2925" Action="None" />
+    <!-- NSubstitute mock verification is complete without property access. -->
+    <Rule Id="S2970" Action="None" />
+    <!-- Fields only assigned in constructor - needed to prevent optimization in reflection tests. -->
+    <Rule Id="S4487" Action="None" />
+    <!-- Set route attributes at top of controller - false positive. -->
+    <Rule Id="S6934" Action="None" />
+    <!-- Use async dispose - sync dispose tests are intentional. -->
+    <Rule Id="S6966" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->
@@ -58,11 +96,11 @@
     <Rule Id="SA1121" Action="None" />
     <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
     <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
@@ -82,6 +120,13 @@
     <Rule Id="SA1618" Action="None" />
     <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="xUnit" RuleNamespace="xUnit">
+    <!-- Use Assert.Single when there's only one collection entry. -->
+    <Rule Id="xUnit2023" Action="Warning" />
+  </Rules>
+  <!-- IDE rules for test assemblies. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/src/Autofac.Pooling/Autofac.Pooling.csproj
+++ b/src/Autofac.Pooling/Autofac.Pooling.csproj
@@ -8,6 +8,8 @@
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Source.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -50,6 +52,10 @@
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Autofac.Pooling/Autofac.Pooling.csproj
+++ b/src/Autofac.Pooling/Autofac.Pooling.csproj
@@ -34,19 +34,18 @@
     <EmbedAllSources>true</EmbedAllSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
-
+  <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
-
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -58,7 +57,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="PoolGetActivatorResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -76,7 +74,6 @@
       <DependentUpon>RegistrationExtensionsResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="PoolGetActivatorResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -91,5 +88,4 @@
       <LastGenOutput>RegistrationExtensionsResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/src/Autofac.Pooling/AutofacPooledObjectPolicy.cs
+++ b/src/Autofac.Pooling/AutofacPooledObjectPolicy.cs
@@ -10,7 +10,7 @@ namespace Autofac.Pooling;
 /// Provides the <see cref="IPooledObjectPolicy{TLimit}"/> needed for creating/returning objects in the pool in an Autofac way.
 /// </summary>
 /// <typeparam name="TPooledObject">The type of object being pooled.</typeparam>
-internal class AutofacPooledObjectPolicy<TPooledObject> : IPooledObjectPolicy<TPooledObject>
+internal sealed class AutofacPooledObjectPolicy<TPooledObject> : IPooledObjectPolicy<TPooledObject>
     where TPooledObject : class
 {
     private readonly Service _poolInstanceService;

--- a/src/Autofac.Pooling/PoolService.cs
+++ b/src/Autofac.Pooling/PoolService.cs
@@ -11,7 +11,7 @@ namespace Autofac.Pooling;
 /// <summary>
 /// Defines a service used to access an <see cref="ObjectPool{T}"/>, ensuring that each pooled item registration gets a different pool.
 /// </summary>
-internal class PoolService : Service, IEquatable<PoolService>
+internal sealed class PoolService : Service, IEquatable<PoolService>
 {
     private readonly IComponentRegistration _pooledItemRegistration;
 

--- a/src/Autofac.Pooling/PooledLifetime.cs
+++ b/src/Autofac.Pooling/PooledLifetime.cs
@@ -8,6 +8,7 @@ namespace Autofac.Pooling;
 /// <summary>
 /// Lifetime wrapper to help us detect if we finished registering in a pooled configuration.
 /// </summary>
+[SuppressMessage("S2094", "S2094", Justification = "Lifetimes are classes, not interfaces. Changing this would be a breaking change.")]
 public class PooledLifetime : CurrentScopeLifetime
 {
 }

--- a/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
+++ b/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
@@ -7,6 +7,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
+++ b/test/Autofac.Pooling.Test/Autofac.Pooling.Test.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -12,6 +14,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Pooling.Test/Common/IPooledService.cs
+++ b/test/Autofac.Pooling.Test/Common/IPooledService.cs
@@ -1,4 +1,4 @@
-﻿namespace Autofac.Pooling.Tests.Shared;
+﻿namespace Autofac.Pooling.Tests.Common;
 
 public interface IPooledService
 {

--- a/test/Autofac.Pooling.Test/Common/OtherPooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Common/OtherPooledComponent.cs
@@ -1,4 +1,4 @@
-﻿namespace Autofac.Pooling.Tests.Shared;
+﻿namespace Autofac.Pooling.Tests.Common;
 
 public class OtherPooledComponent : IPooledService
 {

--- a/test/Autofac.Pooling.Test/Common/PoolTrackingPolicy.cs
+++ b/test/Autofac.Pooling.Test/Common/PoolTrackingPolicy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Autofac.Core;
 
-namespace Autofac.Pooling.Tests.Shared;
+namespace Autofac.Pooling.Tests.Common;
 
 public class PoolTrackingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
     where TLimit : class

--- a/test/Autofac.Pooling.Test/Common/PooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Common/PooledComponent.cs
@@ -4,6 +4,7 @@ using Autofac.Core;
 
 namespace Autofac.Pooling.Tests.Common;
 
+[SuppressMessage("CA1063", "CA1063", Justification = "Dispose remains simple here for testing.")]
 public class PooledComponent : IPooledService, IPooledComponent, IDisposable
 {
     public int GetCalled
@@ -31,6 +32,7 @@ public class PooledComponent : IPooledService, IPooledComponent, IDisposable
         ReturnCalled++;
     }
 
+    [SuppressMessage("CA1063", "CA1063", Justification = "Dispose remains simple here for testing.")]
     public void Dispose()
     {
         DisposeCalled++;

--- a/test/Autofac.Pooling.Test/Common/PooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Common/PooledComponent.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Autofac.Core;
 
-namespace Autofac.Pooling.Tests.Shared;
+namespace Autofac.Pooling.Tests.Common;
 
 public class PooledComponent : IPooledService, IPooledComponent, IDisposable
 {

--- a/test/Autofac.Pooling.Test/ConcurrencyTests.cs
+++ b/test/Autofac.Pooling.Test/ConcurrencyTests.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac.Core;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/ConcurrencyTests.cs
+++ b/test/Autofac.Pooling.Test/ConcurrencyTests.cs
@@ -22,14 +22,18 @@ public class ConcurrencyTests
 
         var container = builder.Build();
 
-        await Task.WhenAll(Enumerable.Range(0, 2000).Select(i => Task.Run(() =>
+        var exception = await Record.ExceptionAsync(async () =>
         {
-            using var scope = container.BeginLifetimeScope();
+            await Task.WhenAll(Enumerable.Range(0, 2000).Select(i => Task.Run(() =>
+            {
+                using var scope = container.BeginLifetimeScope();
 
-            scope.Resolve<IPooledService>();
-        })));
+                scope.Resolve<IPooledService>();
+            })));
 
-        container.Dispose();
+            container.Dispose();
+        });
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/test/Autofac.Pooling.Test/ConcurrencyTests.cs
+++ b/test/Autofac.Pooling.Test/ConcurrencyTests.cs
@@ -41,7 +41,7 @@ public class ConcurrencyTests
     {
         var builder = new ContainerBuilder();
 
-        var blockingPolicy = new BlockingPolicy<PooledComponent>(4);
+        using var blockingPolicy = new BlockingPolicy<PooledComponent>(4);
 
         builder.RegisterType<PooledComponent>().As<IPooledService>()
                                                .PooledInstancePerLifetimeScope(blockingPolicy);
@@ -60,10 +60,11 @@ public class ConcurrencyTests
         container.Dispose();
     }
 
-    private class BlockingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>
+    private class BlockingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit>, IDisposable
         where TLimit : class
     {
         private readonly SemaphoreSlim _semaphore;
+        private bool _disposedValue;
 
         public BlockingPolicy(int maxConcurrentInstances) : base(maxConcurrentInstances)
         {
@@ -86,6 +87,26 @@ public class ConcurrencyTests
             _semaphore.Release();
 
             return base.Return(pooledObject);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _semaphore.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/Autofac.Pooling.Test/DisposableTests.cs
+++ b/test/Autofac.Pooling.Test/DisposableTests.cs
@@ -1,5 +1,5 @@
 ﻿using Autofac.Features.OwnedInstances;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
+++ b/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
@@ -237,7 +237,7 @@ public class ImplicitRelationshipTests
 
         using (var scope1 = container.BeginLifetimeScope())
         {
-            var set = scope1.Resolve<IList<IPooledService>>();
+            scope1.Resolve<IList<IPooledService>>();
 
             // The important point is that each pool goes up by one, meaning that we can track different pools
             // for the same limit type.

--- a/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
+++ b/test/Autofac.Pooling.Test/ImplicitRelationshipTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/LifetimeScopeTests.cs
+++ b/test/Autofac.Pooling.Test/LifetimeScopeTests.cs
@@ -1,5 +1,5 @@
 ﻿using Autofac.Core;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/PolicyTests.cs
+++ b/test/Autofac.Pooling.Test/PolicyTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Autofac.Core;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/PolicyTests.cs
+++ b/test/Autofac.Pooling.Test/PolicyTests.cs
@@ -144,11 +144,9 @@ public class PolicyTests
 
         var container = builder.Build();
 
-        IPooledService pooledInstance;
-
         using (var scope = container.BeginLifetimeScope())
         {
-            pooledInstance = scope.Resolve<IPooledService>(new NamedParameter("Val1", 123), new TypedParameter(typeof(int), 456));
+            var _ = scope.Resolve<IPooledService>(new NamedParameter("Val1", 123), new TypedParameter(typeof(int), 456));
         }
 
         Assert.Collection(policyReceivedParameters,

--- a/test/Autofac.Pooling.Test/PooledComponentTests.cs
+++ b/test/Autofac.Pooling.Test/PooledComponentTests.cs
@@ -1,5 +1,5 @@
 ﻿using Autofac.Features.OwnedInstances;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;

--- a/test/Autofac.Pooling.Test/PoolingTests.cs
+++ b/test/Autofac.Pooling.Test/PoolingTests.cs
@@ -1,4 +1,4 @@
-﻿using Autofac.Pooling.Tests.Shared;
+﻿using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Tests;

--- a/test/Autofac.Pooling.Test/PoolingTests.cs
+++ b/test/Autofac.Pooling.Test/PoolingTests.cs
@@ -1,7 +1,7 @@
 ﻿using Autofac.Pooling.Tests.Common;
 using Xunit;
 
-namespace Autofac.Pooling.Tests;
+namespace Autofac.Pooling.Test;
 
 public class PoolingTest
 {

--- a/test/Autofac.Pooling.Test/RegistrationExtensionsTests.cs
+++ b/test/Autofac.Pooling.Test/RegistrationExtensionsTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Autofac.Builder;
-using Autofac.Pooling.Tests.Shared;
+using Autofac.Pooling.Tests.Common;
 using Xunit;
 
 namespace Autofac.Pooling.Test;
@@ -17,6 +17,7 @@ public class RegistrationExtensionsTests
     }
 
     [Fact]
+    [SuppressMessage("CA2000", "CA2000", Justification = "The container will dispose of the object.")]
     public void NoProvidedInstances()
     {
         var builder = new ContainerBuilder();

--- a/test/Autofac.Pooling.Test/Shared/OtherPooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Shared/OtherPooledComponent.cs
@@ -2,9 +2,9 @@
 
 public class OtherPooledComponent : IPooledService
 {
-    public int GetCalled => throw new System.NotImplementedException();
+    public int GetCalled => 0;
 
-    public int ReturnCalled => throw new System.NotImplementedException();
+    public int ReturnCalled => 0;
 
-    public int DisposeCalled => throw new System.NotImplementedException();
+    public int DisposeCalled => 0;
 }

--- a/test/Autofac.Pooling.Test/Shared/PoolTrackingPolicy.cs
+++ b/test/Autofac.Pooling.Test/Shared/PoolTrackingPolicy.cs
@@ -14,6 +14,8 @@ public class PoolTrackingPolicy<TLimit> : DefaultPooledRegistrationPolicy<TLimit
 
     public override TLimit Get(IComponentContext context, IEnumerable<Parameter> parameters, Func<TLimit> getFromPool)
     {
+        ArgumentNullException.ThrowIfNull(getFromPool);
+
         Interlocked.Increment(ref _outOfPool);
 
         return getFromPool();

--- a/test/Autofac.Pooling.Test/Shared/PooledComponent.cs
+++ b/test/Autofac.Pooling.Test/Shared/PooledComponent.cs
@@ -21,7 +21,7 @@ public class PooledComponent : IPooledService, IPooledComponent, IDisposable
         get; private set;
     }
 
-    public void OnGetFromPool(IComponentContext ctxt, IEnumerable<Parameter> parameters)
+    public void OnGetFromPool(IComponentContext context, IEnumerable<Parameter> parameters)
     {
         GetCalled++;
     }


### PR DESCRIPTION
## Summary

- Adds SonarAnalyzer.CSharp (10.27.0.140913) to all projects
- Introduces unified `build/Source.ruleset` and `build/Test.ruleset` with consistent analyzer configuration
- Fixes all actionable analyzer warnings (code changes per-rule in individual commits)
- Disables rules that are false positives or inapplicable for this project's patterns

## Changes

- **New analyzer**: SonarAnalyzer.CSharp added via PackageReference with PrivateAssets=all
- **Rulesets**: Unified Source.ruleset and Test.ruleset covering Microsoft, Sonar, StyleCop, and xUnit analyzers
- **Code fixes**: Various warning fixes committed individually by rule ID for easy review
- **Zero warnings**: Build completes with no analyzer warnings

## Test plan

- [ ] CI build passes (zero errors, zero warnings)
- [ ] All existing tests pass
- [ ] No public API changes (verify with `dotnet format --verify-no-changes`)